### PR TITLE
Make UUID a non-default feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,9 +16,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Check Formatting
+      run: cargo fmt --check
+    - name: Clippy
+      run: cargo clippy
     - name: Build
       run: cargo build --verbose
+    - name: Run build tests
+      run: cargo build --tests --all-features
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --tests --all-features --verbose
     - name: Run doctests
-      run: cargo test --doc --verbose
+      run: cargo test --doc --all-features --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- The `uuid` feature is now not enabled by default anymore.
+
+### Internal
+
+- Some unnecessary heap allocations were removed.
+
 ## 0.4.0 - 2023-06-16
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 edition = "2021"
 
 [features]
-default = ["uuid"]
+default = []
 uuid = ["dep:uuid"]
 
 [[test]]
@@ -21,12 +21,12 @@ path = "tests/tests.rs"
 required-features = ["uuid"]
 
 [dependencies]
-tokio = { version = "1.28.2", features = ["fs"] }
-uuid = { version = "1.3.4", features = ["v4"], optional = true }
+tokio = { version = "1.34.0", features = ["fs"] }
+uuid = { version = "1.6.1", features = ["v4"], optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.28.2", features = ["rt-multi-thread", "macros"] }
-tokio-test = "0.4.2"
+tokio = { version = "1.34.0", features = ["rt-multi-thread", "macros"] }
+tokio-test = "0.4.3"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ use async_tempfile::TempFile;
 
 #[tokio::main]
 async fn main() {
+    // NOTE: The new() function is available with the `uuid` crate feature.
     let parent = TempFile::new().await.unwrap();
 
     // The cloned reference will not delete the file when dropped.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 #[cfg(feature = "uuid")]
 use uuid::Uuid;
 
+#[cfg(feature = "uuid")]
 const FILE_PREFIX: &'static str = "atmp_";
 
 /// A named temporary file that will be cleaned automatically
@@ -61,7 +62,7 @@ pub struct TempFile {
     /// A shared pointer to the owned (or non-owned) file.
     /// The `Arc` ensures that the enclosed file is kept alive
     /// until all references to it are dropped.
-    core: ManuallyDrop<Arc<Box<TempFileCore>>>,
+    core: ManuallyDrop<Arc<TempFileCore>>,
 }
 
 /// Determines the ownership of a temporary file.
@@ -260,7 +261,7 @@ impl TempFile {
         let file_name = name.as_ref();
         let mut path = dir.clone();
         path.push(file_name);
-        Ok(Self::new_internal(path, Ownership::Owned).await?)
+        Self::new_internal(path, Ownership::Owned).await
     }
 
     /// Creates a new temporary file in the specified location.
@@ -393,7 +394,7 @@ impl TempFile {
             .await?;
         Ok(Self {
             file: ManuallyDrop::new(file),
-            core: ManuallyDrop::new(Arc::new(Box::new(core))),
+            core: ManuallyDrop::new(Arc::new(core)),
         })
     }
 


### PR DESCRIPTION
This removes the `uuid` crate feature from the defaults, disabling the `new`, `new_in` and related functions, leaving `new_with_name` and `new_with_name_in` accessible by default.

Closes #2.