### PR TITLE
Add new and new_in without uuid dependency

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,28 +11,21 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        features: [[], ["--all-features"]]
     steps:
-    - uses: actions/checkout@v3
-    - name: Check Formatting
-      run: cargo fmt --check
-    - name: Clippy (default features)
-      run: cargo clippy
-    - name: Clippy (all features)
-      run: cargo clippy --all-features
-    - name: Build
-      run: cargo build --verbose
-    - name: Run build tests (default features)
-      run: cargo build --tests
-    - name: Run build tests (all features)
-      run: cargo build --tests --all-features
-    - name: Run tests (default features)
-      run: cargo test --tests --verbose
-    - name: Run tests
-      run: cargo test --tests --all-features --verbose
-    - name: Run doctests (default features)
-      run: cargo test --doc --verbose
-    - name: Run doctests (all features)
-      run: cargo test --doc --all-features --verbose
+      - uses: actions/checkout@v2
+      - name: Check Formatting
+        run: cargo fmt --check
+      - name: Clippy
+        run: cargo clippy ${{ join(matrix.features, ' ') }}
+      - name: Build
+        run: cargo build --verbose ${{ join(matrix.features, ' ') }}
+      - name: Run build tests
+        run: cargo build --tests ${{ join(matrix.features, ' ') }}
+      - name: Run tests
+        run: cargo test --tests --verbose ${{ join(matrix.features, ' ') }}
+      - name: Run doctests
+        run: cargo test --doc --verbose ${{ join(matrix.features, ' ') }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,13 +18,21 @@ jobs:
     - uses: actions/checkout@v3
     - name: Check Formatting
       run: cargo fmt --check
-    - name: Clippy
+    - name: Clippy (default features)
       run: cargo clippy
+    - name: Clippy (all features)
+      run: cargo clippy --all-features
     - name: Build
       run: cargo build --verbose
-    - name: Run build tests
+    - name: Run build tests (default features)
+      run: cargo build --tests
+    - name: Run build tests (all features)
       run: cargo build --tests --all-features
+    - name: Run tests (default features)
+      run: cargo test --tests --verbose
     - name: Run tests
       run: cargo test --tests --all-features --verbose
-    - name: Run doctests
+    - name: Run doctests (default features)
+      run: cargo test --doc --verbose
+    - name: Run doctests (all features)
       run: cargo test --doc --all-features --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- The `new` and `new_in` functions now do not rely on the `uuid` feature anymore
+  to generate temporary file names.
 - The `uuid` feature is now not enabled by default anymore.
 
 ### Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - The `new` and `new_in` functions now do not rely on the `uuid` feature anymore
-  to generate temporary file names.
+  for the generation of temporary file names.
 - The `uuid` feature is now not enabled by default anymore.
 
 ### Internal

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ uuid = ["dep:uuid"]
 [[test]]
 name = "tests"
 path = "tests/tests.rs"
-required-features = ["uuid"]
 
 [dependencies]
 tokio = { version = "1.34.0", features = ["fs"] }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ use async_tempfile::TempFile;
 
 #[tokio::main]
 async fn main() {
-    // NOTE: The new() function is available with the `uuid` crate feature.
     let parent = TempFile::new().await.unwrap();
 
     // The cloned reference will not delete the file when dropped.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,11 @@ impl TempFile {
     /// Creates a new temporary file in the specified location.
     /// When the instance goes out of scope, the file will be deleted.
     ///
+    /// ## Crate Features
+    ///
+    /// * `uuid` - When the `uuid` crate feature is enabled, a random UUIDv4 is used to
+    ///   generate the temporary file name.
+    ///
     /// ## Arguments
     ///
     /// * `dir` - The directory to create the file in.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,6 +420,7 @@ struct RandomName {
 }
 
 impl RandomName {
+    #[allow(dead_code)]
     fn new() -> Self {
         let pid = std::process::id();
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,12 @@
-use async_tempfile::{Ownership, TempFile};
+use async_tempfile::TempFile;
+
+#[cfg(feature = "uuid")]
+use async_tempfile::Ownership;
+
+#[cfg(feature = "uuid")]
 use tokio::fs::OpenOptions;
+
+#[cfg(feature = "uuid")]
 use uuid::Uuid;
 
 #[tokio::test]
@@ -41,7 +48,8 @@ async fn ro_file_is_not_dropped_while_still_referenced() {
 }
 
 #[tokio::test]
-async fn borrowed_file_is_not_dropped() {
+#[cfg(feature = "uuid")]
+async fn uuid_borrowed_file_is_not_dropped() {
     let file_name = format!("test_{}", Uuid::new_v4());
     let path = std::env::temp_dir().join(file_name);
     let _original = OpenOptions::new()
@@ -64,7 +72,8 @@ async fn borrowed_file_is_not_dropped() {
 }
 
 #[tokio::test]
-async fn owned_file_is_dropped() {
+#[cfg(feature = "uuid")]
+async fn uuid_owned_file_is_dropped() {
     let file_name = format!("test_{}", Uuid::new_v4());
     let path = std::env::temp_dir().join(file_name);
     let _original = OpenOptions::new()


### PR DESCRIPTION
A follow-up to #2/#3; this adds an implementation for `new`  and `new_in` that works without the `uuid` crate feature. If the `uuid` feature is enabled, UUIDs are used to generate unique filenames; if it is disabled, a combination of the current process ID, local addresses and the current time is used to generate names.