### PR TITLE
Modernize internals, forbid unsafe, and add builder/keep/persist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   prefix, suffix and target directory before creation.
 - [#12](https://github.com/sunsided/async-tempfile-rs/issues/12):
   Added `keep` to disable automatic deletion and `persist` to move a temporary
-  file or directory to a permanent location. Both are cancellation- and
-  panic-safe: deletion is only disabled after the operation succeeds.
+  file or directory to a permanent location. On failure `persist` leaves the
+  temporary intact and reports its path via `PersistError` (see below).
 - [#1](https://github.com/sunsided/async-tempfile-rs/issues/1):
   `drop_async` now removes the file or directory via `tokio::fs` directly when it
   is the sole owner, rather than offloading a synchronous drop to a blocking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,11 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - The crate now declares `#![forbid(unsafe_code)]`. The previous `ManuallyDrop` /
   `unsafe` drop machinery was replaced by safe code that relies on struct field
-  drop order and an `Option`-held handle.
+  drop order to close the file handle before the file is deleted.
+- `persist` now returns a `PersistError` on failure that carries the path of
+  the still-intact temporary, so a failed move (for example cross-device) no
+  longer deletes the data. The local handle is closed before the rename so the
+  move also succeeds on Windows.
 - Automatically generated temporary names are now unpredictable (seeded from the
   OS RNG via `RandomState`, with a per-process counter for guaranteed local
   uniqueness) and created with an exclusive (`O_EXCL`) create, closing a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-06-02
+
+[0.8.0]: https://github.com/sunsided/async-tempfile-rs/releases/tag/v0.8.0
+
+### Added
+
+- [#11](https://github.com/sunsided/async-tempfile-rs/issues/11):
+  Added `TempFile::builder()` and `TempDir::builder()` for configuring the name
+  prefix, suffix and target directory before creation.
+- [#12](https://github.com/sunsided/async-tempfile-rs/issues/12):
+  Added `keep` to disable automatic deletion and `persist` to move a temporary
+  file or directory to a permanent location. Both are cancellation- and
+  panic-safe: deletion is only disabled after the operation succeeds.
+- [#1](https://github.com/sunsided/async-tempfile-rs/issues/1):
+  `drop_async` now removes the file or directory via `tokio::fs` directly when it
+  is the sole owner, rather than offloading a synchronous drop to a blocking
+  thread. The synchronous `Drop` remains an always-armed backstop.
+
+### Changed
+
+- The crate now declares `#![forbid(unsafe_code)]`. The previous `ManuallyDrop` /
+  `unsafe` drop machinery was replaced by safe code that relies on struct field
+  drop order and an `Option`-held handle.
+- Automatically generated temporary names are now unpredictable (seeded from the
+  OS RNG via `RandomState`, with a per-process counter for guaranteed local
+  uniqueness) and created with an exclusive (`O_EXCL`) create, closing a
+  predictable-name / preexisting-file race. User-supplied names keep their
+  previous create-or-open behavior.
+- Bumped the crate to Rust edition 2024 with a declared MSRV of 1.85.
+
 ## [0.7.0] - 2025-02-22
 
 [0.7.0]: https://github.com/sunsided/async-tempfile-rs/releases/tag/v0.7.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-tempfile"
-version = "0.7.0"
+version = "0.8.0"
 description = "Automatically deleted async I/O temporary files."
 documentation = "https://docs.rs/async-tempfile"
 license = "MIT"
@@ -9,7 +9,8 @@ repository = "https://github.com/sunsided/async-tempfile-rs"
 keywords = ["tokio", "temporary-files", "temp"]
 categories = ["asynchronous", "filesystem"]
 readme = "README.md"
-edition = "2021"
+edition = "2024"
+rust-version = "1.85"
 
 [features]
 default = []
@@ -24,7 +25,7 @@ tokio = { version = "1.38.0", features = ["fs", "rt"] }
 uuid = { version = "1.9.1", features = ["v4"], optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.38.0", features = ["rt-multi-thread", "macros", "rt"] }
+tokio = { version = "1.38.0", features = ["rt-multi-thread", "macros", "rt", "time", "io-util"] }
 tokio-test = "0.4.4"
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 [![Crates.io](https://img.shields.io/crates/v/async-tempfile)](https://crates.io/crates/async-tempfile)
 [![Crates.io](https://img.shields.io/crates/l/async-tempfile)](https://crates.io/crates/async-tempfile)
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/sunsided/async-tempfile-rs/rust.yml)
+[![Build](https://img.shields.io/github/actions/workflow/status/sunsided/async-tempfile-rs/rust.yml?branch=main)](https://github.com/sunsided/async-tempfile-rs/actions/workflows/rust.yml)
 [![docs.rs](https://img.shields.io/docsrs/async-tempfile)](https://docs.rs/async-tempfile/)
 [![codecov](https://codecov.io/gh/sunsided/async-tempfile-rs/graph/badge.svg?token=LSY85I6M8Y)](https://codecov.io/gh/sunsided/async-tempfile-rs)
+[![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
 Provides the `TempFile` struct, an asynchronous wrapper based on `tokio::fs`
 for temporary files that will be automatically deleted when the last reference to
@@ -26,5 +27,30 @@ async fn main() {
 
     // The file still exists; it will be deleted when `parent` is dropped.
     assert!(parent.file_path().is_file());
+}
+```
+
+## Builder, keep and persist
+
+```rust
+use async_tempfile::TempFile;
+
+#[tokio::main]
+async fn main() {
+    // Configure a name via prefix/suffix; the file is created with an
+    // exclusive (`O_EXCL`), unpredictable, collision-resistant name.
+    let file = TempFile::builder()
+        .prefix("session_")
+        .suffix(".log")
+        .create()
+        .await
+        .unwrap();
+
+    // Turn the temporary file into a permanent one, or move it elsewhere:
+    // let path = file.keep();                       // disables auto-deletion
+    // let path = file.persist("/data/out.log").await.unwrap(); // moves it
+
+    // Drop it explicitly on an async runtime without blocking the executor.
+    file.drop_async().await;
 }
 ```

--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -1,0 +1,168 @@
+# Taskfile for async-tempfile (https://taskfile.dev)
+# Mirrors the GitHub `rust.yml` CI jobs so `task ci` ≈ the pipeline locally.
+version: '3'
+
+vars:
+  CARGO_PRECOND: command -v cargo
+  CARGO_MSG: "cargo not found — install Rust from https://rustup.rs/"
+
+tasks:
+  default:
+    desc: List available tasks
+    cmds:
+      - task --list --sort=none
+    silent: true
+
+  fmt:
+    desc: Format all Rust sources
+    aliases: [format]
+    preconditions:
+      - sh: '{{.CARGO_PRECOND}}'
+        msg: '{{.CARGO_MSG}}'
+    cmds:
+      - cargo fmt --all
+
+  fmt:check:
+    desc: Check formatting without modifying files
+    preconditions:
+      - sh: '{{.CARGO_PRECOND}}'
+        msg: '{{.CARGO_MSG}}'
+    cmds:
+      - cargo fmt --all -- --check
+
+  lint:
+    desc: Run clippy with all features (warnings as errors)
+    aliases: [lint:check]
+    preconditions:
+      - sh: '{{.CARGO_PRECOND}}'
+        msg: '{{.CARGO_MSG}}'
+    cmds:
+      - cargo clippy --all-targets --all-features -- -D warnings
+
+  lint:fix:
+    desc: Auto-fix clippy lints, then format
+    aliases: [fix]
+    preconditions:
+      - sh: '{{.CARGO_PRECOND}}'
+        msg: '{{.CARGO_MSG}}'
+    cmds:
+      - cargo clippy --all-targets --all-features --fix --allow-dirty --allow-staged
+      - task: fmt
+
+  check:
+    desc: All static checks (format check, clippy, type-check)
+    cmds:
+      - task: fmt:check
+      - task: lint
+      - cargo check --all-targets --all-features
+
+  build:
+    desc: Build the crate (default features)
+    preconditions:
+      - sh: '{{.CARGO_PRECOND}}'
+        msg: '{{.CARGO_MSG}}'
+    cmds:
+      - cargo build --all-targets
+
+  build:allfeatures:
+    desc: Build with all features
+    cmds:
+      - cargo build --all-targets --all-features
+
+  build:nofeatures:
+    desc: Build with no default features
+    cmds:
+      - cargo build --all-targets --no-default-features
+
+  test:
+    desc: Run the test suite with all features
+    preconditions:
+      - sh: '{{.CARGO_PRECOND}}'
+        msg: '{{.CARGO_MSG}}'
+    cmds:
+      - cargo test --all-features {{.CLI_ARGS}}
+
+  test:nofeatures:
+    desc: Run the test suite with no default features
+    cmds:
+      - cargo test --no-default-features {{.CLI_ARGS}}
+
+  test:doc:
+    desc: Run doctests with all features
+    cmds:
+      - cargo test --doc --all-features
+
+  test:loom:
+    desc: Run the loom concurrency model-checker (nightly tier)
+    preconditions:
+      - sh: '{{.CARGO_PRECOND}}'
+        msg: '{{.CARGO_MSG}}'
+    env:
+      RUSTFLAGS: --cfg loom
+    cmds:
+      - cargo test --test loom_ownership
+
+  cov:
+    desc: Generate code coverage via cargo-llvm-cov + nextest (mirrors CI)
+    preconditions:
+      - sh: command -v cargo-llvm-cov
+        msg: "cargo-llvm-cov not found — cargo install cargo-llvm-cov"
+      - sh: command -v cargo-nextest
+        msg: "cargo-nextest not found — cargo install cargo-nextest"
+    cmds:
+      - cargo llvm-cov nextest --all-features --lcov --output-path lcov.info
+
+  doc:
+    desc: Build rustdoc with all features
+    cmds:
+      - cargo doc --all-features --no-deps
+
+  doc:open:
+    desc: Build and open rustdoc in the browser
+    cmds:
+      - cargo doc --all-features --no-deps --open
+
+  spell:
+    desc: Check spelling with codespell (mirrors CI)
+    preconditions:
+      - sh: command -v codespell
+        msg: "codespell not found — pip install codespell"
+    cmds:
+      - codespell
+
+  fuzz:
+    desc: Run a fuzz target (nightly + cargo-fuzz; requires a fuzz/ crate)
+    preconditions:
+      - sh: command -v cargo-fuzz
+        msg: "cargo-fuzz not found — cargo install cargo-fuzz"
+      - sh: rustup toolchain list | grep -q nightly
+        msg: "Rust nightly toolchain required — rustup toolchain install nightly"
+    cmds:
+      - cargo +nightly fuzz run {{.CLI_ARGS}}
+
+  fuzz:list:
+    desc: List available fuzz targets
+    preconditions:
+      - sh: command -v cargo-fuzz
+        msg: "cargo-fuzz not found — cargo install cargo-fuzz"
+    cmds:
+      - cargo +nightly fuzz list
+
+  ci:
+    desc: Run the full CI sequence locally (format, lint, build, tests, docs)
+    cmds:
+      - task: fmt:check
+      - task: lint
+      - task: build:nofeatures
+      - task: build:allfeatures
+      - task: test
+      - task: test:nofeatures
+      - task: test:doc
+      - task: doc
+
+  clean:
+    desc: Remove cargo build artifacts
+    status:
+      - test ! -d target
+    cmds:
+      - cargo clean

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,134 @@
+use crate::tempdir::DIR_PREFIX;
+use crate::tempfile::FILE_PREFIX;
+use crate::{Error, TempDir, TempFile};
+use std::path::PathBuf;
+
+/// A builder for configuring and creating a [`TempFile`].
+///
+/// Obtain one via [`TempFile::builder`]. The file name is composed as
+/// `{prefix}{random}{suffix}`, where the random core is unpredictable and
+/// collision-resistant, and the file is created with an exclusive
+/// (`O_EXCL`) create so it never clobbers an existing file.
+///
+/// ## Example
+///
+/// ```
+/// # use async_tempfile::{TempFile, Error};
+/// # let _ = tokio_test::block_on(async {
+/// let file = TempFile::builder()
+///     .prefix("session_")
+///     .suffix(".tmp")
+///     .dir(std::env::temp_dir())
+///     .create()
+///     .await?;
+///
+/// let name = file.file_path().file_name().unwrap().to_string_lossy().into_owned();
+/// assert!(name.starts_with("session_"));
+/// assert!(name.ends_with(".tmp"));
+/// # Ok::<(), Error>(())
+/// # });
+/// ```
+#[derive(Debug, Clone)]
+pub struct TempFileBuilder {
+    dir: Option<PathBuf>,
+    prefix: String,
+    suffix: String,
+}
+
+impl TempFileBuilder {
+    pub(crate) fn new() -> Self {
+        Self {
+            dir: None,
+            prefix: FILE_PREFIX.to_string(),
+            suffix: String::new(),
+        }
+    }
+
+    /// Sets the file name prefix. Defaults to `atmp_`.
+    pub fn prefix<S: Into<String>>(mut self, prefix: S) -> Self {
+        self.prefix = prefix.into();
+        self
+    }
+
+    /// Sets the file name suffix (for example a file extension). Defaults to empty.
+    pub fn suffix<S: Into<String>>(mut self, suffix: S) -> Self {
+        self.suffix = suffix.into();
+        self
+    }
+
+    /// Sets the directory to create the file in. Defaults to the system
+    /// temporary directory ([`std::env::temp_dir`]).
+    pub fn dir<P: Into<PathBuf>>(mut self, dir: P) -> Self {
+        self.dir = Some(dir.into());
+        self
+    }
+
+    /// Creates the temporary file with the configured options.
+    pub async fn create(self) -> Result<TempFile, Error> {
+        let dir = self.dir.unwrap_or_else(std::env::temp_dir);
+        TempFile::create_with_affixes(&dir, &self.prefix, &self.suffix).await
+    }
+}
+
+/// A builder for configuring and creating a [`TempDir`].
+///
+/// Obtain one via [`TempDir::builder`]. The directory name is composed as
+/// `{prefix}{random}{suffix}` with an unpredictable, collision-resistant random
+/// core, created with an exclusive create.
+///
+/// ## Example
+///
+/// ```
+/// # use async_tempfile::{TempDir, Error};
+/// # let _ = tokio_test::block_on(async {
+/// let dir = TempDir::builder()
+///     .prefix("workspace_")
+///     .create()
+///     .await?;
+///
+/// let name = dir.dir_path().file_name().unwrap().to_string_lossy().into_owned();
+/// assert!(name.starts_with("workspace_"));
+/// # Ok::<(), Error>(())
+/// # });
+/// ```
+#[derive(Debug, Clone)]
+pub struct TempDirBuilder {
+    root: Option<PathBuf>,
+    prefix: String,
+    suffix: String,
+}
+
+impl TempDirBuilder {
+    pub(crate) fn new() -> Self {
+        Self {
+            root: None,
+            prefix: DIR_PREFIX.to_string(),
+            suffix: String::new(),
+        }
+    }
+
+    /// Sets the directory name prefix. Defaults to `atmpd_`.
+    pub fn prefix<S: Into<String>>(mut self, prefix: S) -> Self {
+        self.prefix = prefix.into();
+        self
+    }
+
+    /// Sets the directory name suffix. Defaults to empty.
+    pub fn suffix<S: Into<String>>(mut self, suffix: S) -> Self {
+        self.suffix = suffix.into();
+        self
+    }
+
+    /// Sets the root directory to create the directory in. Defaults to the
+    /// system temporary directory ([`std::env::temp_dir`]).
+    pub fn dir<P: Into<PathBuf>>(mut self, root: P) -> Self {
+        self.root = Some(root.into());
+        self
+    }
+
+    /// Creates the temporary directory with the configured options.
+    pub async fn create(self) -> Result<TempDir, Error> {
+        let root = self.root.unwrap_or_else(std::env::temp_dir);
+        TempDir::create_with_affixes(&root, &self.prefix, &self.suffix).await
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,5 @@
 use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
 
 #[derive(Debug)]
 pub enum Error {
@@ -25,5 +26,43 @@ impl std::error::Error for Error {}
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
         Self::Io(e)
+    }
+}
+
+/// The error returned by [`crate::TempFile::persist`] and
+/// [`crate::TempDir::persist`] when the move to the target path fails.
+///
+/// On failure the temporary file or directory is **not** deleted: it is left in
+/// place at [`PersistError::path`] so the caller can recover the data instead of
+/// losing it. To restore automatic cleanup, re-wrap that path with
+/// `from_existing(path, Ownership::Owned)`.
+#[derive(Debug)]
+pub struct PersistError {
+    /// The underlying error that prevented the move (for example a cross-device
+    /// rename, a permission error, or a missing target directory).
+    pub error: Error,
+    /// The path at which the temporary file or directory still resides.
+    pub path: PathBuf,
+}
+
+impl Display for PersistError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "failed to persist temporary at {:?}: {}",
+            self.path, self.error
+        )
+    }
+}
+
+impl std::error::Error for PersistError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
+impl From<PersistError> for Error {
+    fn from(e: PersistError) -> Self {
+        e.error
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -36,6 +36,11 @@ impl From<std::io::Error> for Error {
 /// place at [`PersistError::path`] so the caller can recover the data instead of
 /// losing it. To restore automatic cleanup, re-wrap that path with
 /// `from_existing(path, Ownership::Owned)`.
+///
+/// There is intentionally no `From<PersistError> for Error` conversion: a
+/// blanket `?` would silently drop [`PersistError::path`], the one piece of
+/// information that makes recovery possible. Handle the two fields explicitly,
+/// or use `map_err(|e| e.error)` if you only care about the underlying error.
 #[derive(Debug)]
 pub struct PersistError {
     /// The underlying error that prevented the move (for example a cross-device
@@ -58,11 +63,5 @@ impl Display for PersistError {
 impl std::error::Error for PersistError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(&self.error)
-    }
-}
-
-impl From<PersistError> for Error {
-    fn from(e: PersistError) -> Self {
-        e.error
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,25 +24,28 @@
 //!
 //! ## Features
 //!
-//! * `uuid` - (Default) Enables random file name generation based on the [`uuid`](https://crates.io/crates/uuid) crate.
-//!            Provides the `new` and `new_in`, as well as the `new_with_uuid*` group of methods.
+//! * `uuid` - Enables UUID-based random file name generation via the [`uuid`](https://crates.io/crates/uuid) crate
+//!   and the `new_with_uuid*` group of methods. Not enabled by default; `new`/`new_in` work without it.
 
 // Document crate features on docs.rs.
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Required for dropping the file.
-#![allow(unsafe_code)]
+// This crate deletes files purely from safe code; no `unsafe` is permitted.
+#![forbid(unsafe_code)]
 
+mod builder;
 mod errors;
 mod random_name;
 mod tempdir;
 mod tempfile;
 
+pub use builder::{TempDirBuilder, TempFileBuilder};
 pub use errors::Error;
 #[cfg(not(feature = "uuid"))]
 pub(crate) use random_name::RandomName;
-use std::fmt::Debug;
 pub use tempdir::TempDir;
 pub use tempfile::TempFile;
+
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Determines the ownership of a temporary file or directory.
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
@@ -53,4 +56,39 @@ pub enum Ownership {
     /// The file or directory is borrowed by [`TempFile`] and will be left untouched
     /// when the last reference to it is dropped.
     Borrowed,
+}
+
+/// Lock-free, interior-mutable storage of an [`Ownership`] value, shared across
+/// all clones via the `Arc`-wrapped core.
+///
+/// Lock-free is a hard requirement, not an optimization: the value is read from
+/// `Drop`, which may run on a runtime worker thread and therefore must never
+/// block on a lock. `keep`, `persist`, and `drop_async` flip it to `Borrowed`
+/// to disable automatic deletion.
+pub(crate) struct AtomicOwnership(AtomicBool);
+
+impl AtomicOwnership {
+    /// Creates a new value from the given ownership (`Owned` == `true`).
+    pub(crate) fn new(ownership: Ownership) -> Self {
+        Self(AtomicBool::new(matches!(ownership, Ownership::Owned)))
+    }
+
+    /// Returns the current ownership.
+    pub(crate) fn get(&self) -> Ownership {
+        if self.is_owned() {
+            Ownership::Owned
+        } else {
+            Ownership::Borrowed
+        }
+    }
+
+    /// Returns `true` if the value is currently `Owned`.
+    pub(crate) fn is_owned(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+
+    /// Flips the value to `Borrowed`, disabling automatic deletion. Idempotent.
+    pub(crate) fn set_borrowed(&self) {
+        self.0.store(false, Ordering::Release);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,13 +39,31 @@ mod tempdir;
 mod tempfile;
 
 pub use builder::{TempDirBuilder, TempFileBuilder};
-pub use errors::Error;
+pub use errors::{Error, PersistError};
 #[cfg(not(feature = "uuid"))]
 pub(crate) use random_name::RandomName;
 pub use tempdir::TempDir;
 pub use tempfile::TempFile;
 
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Returns whether `path` is a directory, using async I/O so the calling task
+/// does not block a runtime worker thread on the `stat` syscall.
+pub(crate) async fn path_is_dir(path: &Path) -> bool {
+    tokio::fs::metadata(path)
+        .await
+        .map(|m| m.is_dir())
+        .unwrap_or(false)
+}
+
+/// Returns whether `path` is a regular file, using async I/O (see [`path_is_dir`]).
+pub(crate) async fn path_is_file(path: &Path) -> bool {
+    tokio::fs::metadata(path)
+        .await
+        .map(|m| m.is_file())
+        .unwrap_or(false)
+}
 
 /// Determines the ownership of a temporary file or directory.
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]

--- a/src/random_name.rs
+++ b/src/random_name.rs
@@ -1,4 +1,10 @@
+use std::hash::{BuildHasher, Hasher, RandomState};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::SystemTime;
+
+/// Strictly monotonic per-process counter. Guarantees that two names generated
+/// within the same process never collide, even when created at the same instant.
+static COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Represents a randomly generated file name.
 pub(crate) struct RandomName {
@@ -6,21 +12,29 @@ pub(crate) struct RandomName {
 }
 
 impl RandomName {
-    #[allow(dead_code)]
+    // Only used by the non-`uuid` code path; the `uuid` feature generates names
+    // from UUIDv4 instead, leaving this dead outside of tests.
+    #[cfg_attr(feature = "uuid", allow(dead_code))]
     pub fn new(prefix: &str) -> Self {
         let pid = std::process::id();
 
-        // Using the address of a local variable for extra variation.
-        let marker = &pid as *const _ as usize;
+        // OS-seeded entropy: `RandomState`'s keys are derived from the operating
+        // system RNG, so hashing empty input yields ~64 random bits per call.
+        // This makes generated names unpredictable (no symlink/preexisting-file
+        // races) without pulling in an RNG dependency.
+        let entropy = RandomState::new().build_hasher().finish();
 
-        // Current timestamp for added variation.
+        // Strictly monotonic within the process for guaranteed local uniqueness.
+        let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+
+        // Wall-clock time for additional cross-process variation.
         let now = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap_or(std::time::Duration::from_secs(0));
         let (secs, subsec_nanos) = (now.as_secs(), now.subsec_nanos());
 
         Self {
-            name: format!("{}{}{:x}{:x}{:x}", prefix, pid, marker, secs, subsec_nanos),
+            name: format!("{prefix}{pid:x}{secs:x}{subsec_nanos:x}{entropy:x}{counter:x}"),
         }
     }
 

--- a/src/tempdir.rs
+++ b/src/tempdir.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "uuid"))]
 use crate::RandomName;
-use crate::{AtomicOwnership, Error, Ownership};
+use crate::{AtomicOwnership, Error, Ownership, PersistError};
 use std::borrow::Borrow;
 use std::fmt::{Debug, Formatter};
 use std::io::ErrorKind;
@@ -33,11 +33,10 @@ enum DirCreateMode {
 /// A named temporary directory that will be cleaned automatically
 /// after the last reference to it is dropped.
 pub struct TempDir {
-    /// A local reference to the directory.
-    ///
-    /// Field order matters: `dir` is declared before `core` so the local value
-    /// is dropped before the shared `core` is released and the directory is
-    /// deleted, mirroring [`crate::TempFile`].
+    /// A local copy of the directory path. Unlike [`crate::TempFile`]'s file
+    /// handle there is no OS resource to release here, so field drop order does
+    /// not affect deletion; the field is laid out before `core` purely to mirror
+    /// the `TempFile` layout.
     dir: PathBuf,
 
     /// A shared pointer to the owned (or non-owned) directory.
@@ -225,7 +224,7 @@ impl TempDir {
         root_dir: P,
     ) -> Result<Self, Error> {
         let root = root_dir.borrow();
-        if !root.is_dir() {
+        if !crate::path_is_dir(root).await {
             return Err(Error::InvalidDirectory);
         }
         let path = root.join(name.as_ref());
@@ -278,7 +277,7 @@ impl TempDir {
     /// * `path` - The path of the directory to wrap.
     /// * `ownership` - The ownership of the directory.
     pub async fn from_existing(path: PathBuf, ownership: Ownership) -> Result<Self, Error> {
-        if !path.is_dir() {
+        if !crate::path_is_dir(&path).await {
             return Err(Error::InvalidDirectory);
         }
         Self::new_internal(path, ownership, DirCreateMode::OpenExisting).await
@@ -367,22 +366,33 @@ impl TempDir {
     /// new path. The directory will no longer be deleted automatically.
     ///
     /// The move is performed with [`tokio::fs::rename`] and therefore must stay
-    /// on the same filesystem (a cross-device move returns an I/O error).
+    /// on the same filesystem (a cross-device move returns an error).
     ///
-    /// This is cancellation- and panic-safe: deletion is only disabled *after*
-    /// the rename succeeds, so if the future is dropped or the rename fails, the
-    /// original temporary directory is still cleaned up.
+    /// On failure the temporary directory is **not** deleted: it is left at its
+    /// original location and that path is returned in [`PersistError::path`], so
+    /// no data is lost. The caller may re-wrap it with [`TempDir::from_existing`]
+    /// to restore automatic cleanup, or delete it.
     ///
     /// ## Arguments
     ///
     /// * `target` - The destination path to move the directory to.
-    pub async fn persist<P: AsRef<Path>>(self, target: P) -> Result<PathBuf, Error> {
+    pub async fn persist<P: AsRef<Path>>(self, target: P) -> Result<PathBuf, PersistError> {
         let target = target.as_ref().to_path_buf();
-        // Backstop ordering: rename first, disarm only on success. See
-        // `TempFile::persist` for the cancellation-safety reasoning.
-        tokio::fs::rename(&self.core.path, &target).await?;
-        self.core.ownership.set_borrowed();
-        Ok(target)
+        match tokio::fs::rename(&self.core.path, &target).await {
+            Ok(()) => {
+                self.core.ownership.set_borrowed();
+                Ok(target)
+            }
+            Err(e) => {
+                // Preserve the caller's data: leave the directory in place and
+                // report where it is, rather than deleting it on the way out.
+                self.core.ownership.set_borrowed();
+                Err(PersistError {
+                    error: Error::Io(e),
+                    path: self.core.path.clone(),
+                })
+            }
+        }
     }
 
     /// Asynchronously drops the [`TempDir`] instance, removing the directory via
@@ -436,7 +446,7 @@ impl TempDir {
         prefix: &str,
         suffix: &str,
     ) -> Result<Self, Error> {
-        if !root.is_dir() {
+        if !crate::path_is_dir(root).await {
             return Err(Error::InvalidDirectory);
         }
         let mut last_err = None;

--- a/src/tempdir.rs
+++ b/src/tempdir.rs
@@ -1,39 +1,62 @@
 #[cfg(not(feature = "uuid"))]
 use crate::RandomName;
-use crate::{Error, Ownership};
+use crate::{AtomicOwnership, Error, Ownership};
 use std::borrow::Borrow;
 use std::fmt::{Debug, Formatter};
-use std::mem::ManuallyDrop;
+use std::io::ErrorKind;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 #[cfg(feature = "uuid")]
 use uuid::Uuid;
 
-const DIR_PREFIX: &str = "atmpd_";
+pub(crate) const DIR_PREFIX: &str = "atmpd_";
+
+/// Maximum number of attempts to find a free name when creating a directory
+/// with a randomly generated, collision-resistant name.
+const MAX_NAME_ATTEMPTS: usize = 16;
+
+/// How the underlying directory should be created.
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum DirCreateMode {
+    /// Create a brand-new directory, failing if it already exists. Used for
+    /// unpredictable, auto-generated names so two temporaries never share a dir.
+    Exclusive,
+    /// Create the directory and any missing parents (idempotent if it exists).
+    /// Used for user-supplied names, preserving historic behavior.
+    CreateAll,
+    /// Do not create; the directory is expected to already exist. Used by
+    /// `from_existing`.
+    OpenExisting,
+}
 
 /// A named temporary directory that will be cleaned automatically
 /// after the last reference to it is dropped.
 pub struct TempDir {
     /// A local reference to the directory.
-    dir: ManuallyDrop<PathBuf>,
+    ///
+    /// Field order matters: `dir` is declared before `core` so the local value
+    /// is dropped before the shared `core` is released and the directory is
+    /// deleted, mirroring [`crate::TempFile`].
+    dir: PathBuf,
 
     /// A shared pointer to the owned (or non-owned) directory.
     /// The `Arc` ensures that the enclosed dir is kept alive
     /// until all references to it are dropped.
-    core: ManuallyDrop<Arc<TempDirCore>>,
+    core: Arc<TempDirCore>,
 }
 
-/// The instance that tracks the temporary file.
-/// If dropped, the file will be deleted.
+/// The instance that tracks the temporary directory.
+/// If dropped, the directory will be deleted.
 struct TempDirCore {
-    /// The path of the contained file.
+    /// The path of the contained directory.
     path: PathBuf,
 
-    /// A hacky approach to allow for "non-owned" files.
-    /// If set to `Ownership::Owned`, the file specified in `path` will be deleted
-    /// when this instance is dropped. If set to `Ownership::Borrowed`, the file will be kept.
-    ownership: Ownership,
+    /// Whether the directory specified in `path` is owned (and deleted on drop)
+    /// or merely borrowed. Stored atomically because it is read from `Drop`,
+    /// which must never block on a lock, and mutated by
+    /// `keep`/`persist`/`drop_async`.
+    ownership: AtomicOwnership,
 }
 
 impl TempDir {
@@ -77,7 +100,7 @@ impl TempDir {
     /// # use async_tempfile::{TempDir, Error};
     /// # use tokio::fs;
     /// # let _ = tokio_test::block_on(async {
-    /// let dir = TempDir::new_with_name("temporary.dir").await?;
+    /// let dir = TempDir::new_with_name("new_with_name_example.dir").await?;
     ///
     /// // The directory exists.
     /// let dir_path = dir.dir_path().clone();
@@ -132,6 +155,9 @@ impl TempDir {
     /// Creates a new temporary directory in the specified location.
     /// When the instance goes out of scope, the directory will be deleted.
     ///
+    /// The directory is created with a collision-resistant, unpredictable name
+    /// using an exclusive create, so it never reuses an existing directory.
+    ///
     /// ## Crate Features
     ///
     /// * `uuid` - When the `uuid` crate feature is enabled, a random UUIDv4 is used to
@@ -162,17 +188,7 @@ impl TempDir {
     /// # Ok::<(), Error>(())
     /// # });
     pub async fn new_in<P: Borrow<Path>>(root_dir: P) -> Result<Self, Error> {
-        #[cfg(feature = "uuid")]
-        {
-            let id = Uuid::new_v4();
-            Self::new_with_uuid_in(id, root_dir).await
-        }
-
-        #[cfg(not(feature = "uuid"))]
-        {
-            let name = RandomName::new(DIR_PREFIX);
-            Self::new_with_name_in(name, root_dir).await
-        }
+        Self::create_with_affixes(root_dir.borrow(), DIR_PREFIX, "").await
     }
 
     /// Creates a new temporary directory in the specified location.
@@ -190,7 +206,7 @@ impl TempDir {
     /// # use tokio::fs;
     /// # let _ = tokio_test::block_on(async {
     /// let path = std::env::temp_dir();
-    /// let dir = TempDir::new_with_name_in("temporary.dir", path).await?;
+    /// let dir = TempDir::new_with_name_in("new_with_name_in_example.dir", path).await?;
     ///
     /// // The directory exists.
     /// let dir_path = dir.dir_path().clone();
@@ -208,14 +224,12 @@ impl TempDir {
         name: N,
         root_dir: P,
     ) -> Result<Self, Error> {
-        let dir = root_dir.borrow();
-        if !dir.is_dir() {
+        let root = root_dir.borrow();
+        if !root.is_dir() {
             return Err(Error::InvalidDirectory);
         }
-        let file_name = name.as_ref();
-        let mut path = PathBuf::from(dir);
-        path.push(file_name);
-        Self::new_internal(path, Ownership::Owned).await
+        let path = root.join(name.as_ref());
+        Self::new_internal(path, Ownership::Owned, DirCreateMode::CreateAll).await
     }
 
     /// Creates a new directory file in the specified location.
@@ -251,8 +265,8 @@ impl TempDir {
     #[cfg_attr(docsrs, doc(cfg(feature = "uuid")))]
     #[cfg(feature = "uuid")]
     pub async fn new_with_uuid_in<P: Borrow<Path>>(uuid: Uuid, root_dir: P) -> Result<Self, Error> {
-        let file_name = format!("{}{}", DIR_PREFIX, uuid);
-        Self::new_with_name_in(file_name, root_dir).await
+        let dir_name = format!("{DIR_PREFIX}{uuid}");
+        Self::new_with_name_in(dir_name, root_dir).await
     }
 
     /// Wraps a new instance of this type around an existing directory.
@@ -267,7 +281,29 @@ impl TempDir {
         if !path.is_dir() {
             return Err(Error::InvalidDirectory);
         }
-        Self::new_internal(path, ownership).await
+        Self::new_internal(path, ownership, DirCreateMode::OpenExisting).await
+    }
+
+    /// Creates a builder for configuring a new temporary directory
+    /// (prefix, suffix, root) before creating it.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # use async_tempfile::{TempDir, Error};
+    /// # let _ = tokio_test::block_on(async {
+    /// let dir = TempDir::builder()
+    ///     .prefix("build_")
+    ///     .create()
+    ///     .await?;
+    ///
+    /// let name = dir.dir_path().file_name().unwrap().to_string_lossy().into_owned();
+    /// assert!(name.starts_with("build_"));
+    /// # Ok::<(), Error>(())
+    /// # });
+    /// ```
+    pub fn builder() -> crate::TempDirBuilder {
+        crate::TempDirBuilder::new()
     }
 
     /// Returns the path of the underlying temporary directory.
@@ -276,9 +312,8 @@ impl TempDir {
     }
 
     /// Creates a new [`TempDir`] instance that shares the same underlying
-    /// file handle as the existing [`TempDir`] instance.
-    /// Reads, writes, and seeks will affect both [`TempDir`] instances simultaneously.
-    #[allow(dead_code)]
+    /// directory as the existing [`TempDir`] instance. The directory is removed
+    /// once the last of the shared instances is dropped.
     pub async fn try_clone(&self) -> Result<TempDir, Error> {
         Ok(TempDir {
             core: self.core.clone(),
@@ -298,14 +333,64 @@ impl TempDir {
     /// # });
     /// ```
     pub fn ownership(&self) -> Ownership {
-        self.core.ownership
+        self.core.ownership.get()
     }
 
-    /// Asynchronously drops the [`TempDir`] instance by moving the drop operation
-    /// to a blocking thread, avoiding potential blocking of the async runtime.
+    /// Disables automatic deletion and returns the path of the underlying
+    /// directory, turning the temporary directory into a permanent one.
     ///
-    /// This method is useful in cases where manually handling the blocking drop
-    /// within an async context is required.
+    /// This affects every clone that shares the same underlying directory: none
+    /// of them will delete it when dropped.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # use async_tempfile::{TempDir, Error};
+    /// # use tokio::fs;
+    /// # let _ = tokio_test::block_on(async {
+    /// let dir = TempDir::new().await?;
+    /// let path = dir.keep();
+    ///
+    /// // The directory still exists after the handle is dropped.
+    /// assert!(fs::metadata(path.clone()).await.is_ok());
+    /// # fs::remove_dir_all(path).await.ok();
+    /// # Ok::<(), Error>(())
+    /// # });
+    /// ```
+    pub fn keep(self) -> PathBuf {
+        let path = self.core.path.clone();
+        self.core.ownership.set_borrowed();
+        path
+    }
+
+    /// Persists the temporary directory by moving it to `target`, returning the
+    /// new path. The directory will no longer be deleted automatically.
+    ///
+    /// The move is performed with [`tokio::fs::rename`] and therefore must stay
+    /// on the same filesystem (a cross-device move returns an I/O error).
+    ///
+    /// This is cancellation- and panic-safe: deletion is only disabled *after*
+    /// the rename succeeds, so if the future is dropped or the rename fails, the
+    /// original temporary directory is still cleaned up.
+    ///
+    /// ## Arguments
+    ///
+    /// * `target` - The destination path to move the directory to.
+    pub async fn persist<P: AsRef<Path>>(self, target: P) -> Result<PathBuf, Error> {
+        let target = target.as_ref().to_path_buf();
+        // Backstop ordering: rename first, disarm only on success. See
+        // `TempFile::persist` for the cancellation-safety reasoning.
+        tokio::fs::rename(&self.core.path, &target).await?;
+        self.core.ownership.set_borrowed();
+        Ok(target)
+    }
+
+    /// Asynchronously drops the [`TempDir`] instance, removing the directory via
+    /// [`tokio::fs::remove_dir_all`] without blocking the runtime when this is
+    /// the last reference to an owned directory.
+    ///
+    /// The synchronous `Drop` remains armed as a backstop, so a cancelled or
+    /// panicking `drop_async` still cleans up the directory.
     ///
     /// ## Example
     /// ```
@@ -320,24 +405,91 @@ impl TempDir {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// # });
     /// ```
-    ///
-    /// Note: This function spawns a blocking task for the drop operation.
     pub async fn drop_async(self) {
-        tokio::task::spawn_blocking(move || drop(self)).await.ok();
+        let TempDir { dir, core } = self;
+        drop(dir);
+
+        let Some(core) = Arc::into_inner(core) else {
+            return;
+        };
+
+        if core.ownership.is_owned() {
+            // Still marked owned: a cancellation or panic at the await point
+            // leaves `core`'s synchronous `Drop` to delete the directory.
+            match tokio::fs::remove_dir_all(&core.path).await {
+                Ok(()) => core.ownership.set_borrowed(),
+                Err(e) if e.kind() == ErrorKind::NotFound => core.ownership.set_borrowed(),
+                // Leave armed: the synchronous `Drop` below retries removal.
+                Err(_) => {}
+            }
+        }
+
+        drop(core);
     }
 
-    async fn new_internal<P: Borrow<Path>>(path: P, ownership: Ownership) -> Result<Self, Error> {
-        // Create the directory and all its parents.
-        tokio::fs::create_dir_all(path.borrow()).await?;
+    /// Creates a directory named `{prefix}{random}{suffix}` with an
+    /// unpredictable, collision-resistant random core, using an exclusive create
+    /// and retrying on the (very unlikely) collision. Shared by `new_in` and
+    /// [`crate::TempDirBuilder`].
+    pub(crate) async fn create_with_affixes(
+        root: &Path,
+        prefix: &str,
+        suffix: &str,
+    ) -> Result<Self, Error> {
+        if !root.is_dir() {
+            return Err(Error::InvalidDirectory);
+        }
+        let mut last_err = None;
+        for _ in 0..MAX_NAME_ATTEMPTS {
+            let name = format!("{prefix}{}{suffix}", Self::random_core_name());
+            match Self::new_internal(root.join(name), Ownership::Owned, DirCreateMode::Exclusive)
+                .await
+            {
+                Ok(dir) => return Ok(dir),
+                Err(Error::Io(e)) if e.kind() == ErrorKind::AlreadyExists => {
+                    last_err = Some(Error::Io(e));
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Err(last_err.unwrap_or(Error::InvalidDirectory))
+    }
+
+    /// Generates the unpredictable, collision-resistant random core of a name,
+    /// without any prefix or suffix.
+    fn random_core_name() -> String {
+        #[cfg(feature = "uuid")]
+        {
+            Uuid::new_v4().to_string()
+        }
+
+        #[cfg(not(feature = "uuid"))]
+        {
+            RandomName::new("").as_str().to_string()
+        }
+    }
+
+    async fn new_internal<P: Borrow<Path>>(
+        path: P,
+        ownership: Ownership,
+        mode: DirCreateMode,
+    ) -> Result<Self, Error> {
+        let path = path.borrow();
+
+        match mode {
+            DirCreateMode::Exclusive => tokio::fs::create_dir(path).await?,
+            DirCreateMode::CreateAll => tokio::fs::create_dir_all(path).await?,
+            DirCreateMode::OpenExisting => {}
+        }
 
         let core = TempDirCore {
-            ownership,
-            path: PathBuf::from(path.borrow()),
+            ownership: AtomicOwnership::new(ownership),
+            path: PathBuf::from(path),
         };
 
         Ok(Self {
-            dir: ManuallyDrop::new(PathBuf::from(path.borrow())),
-            core: ManuallyDrop::new(Arc::new(core)),
+            dir: PathBuf::from(path),
+            core: Arc::new(core),
         })
     }
 
@@ -348,31 +500,19 @@ impl TempDir {
     }
 }
 
-/// Ensures the file handles are closed before the core reference is freed.
-/// If the core reference would be freed while handles are still open, it is
-/// possible that the underlying file cannot be deleted.
-impl Drop for TempDir {
-    fn drop(&mut self) {
-        // Ensure all directory handles are closed before we attempt to delete the directory itself via core.
-        drop(unsafe { ManuallyDrop::take(&mut self.dir) });
-        drop(unsafe { ManuallyDrop::take(&mut self.core) });
-    }
-}
-
 /// Ensures that the underlying directory is deleted if this is an owned instance.
 /// If the underlying directory is not owned, this operation does nothing.
 impl Drop for TempDirCore {
-    /// See also [`TempDirCore::close`].
     fn drop(&mut self) {
-        // Ensure we don't drop borrowed directories.
-        if self.ownership != Ownership::Owned {
+        // Ensure we don't drop borrowed directories. Read via the lock-free
+        // atomic: `Drop` may run on a runtime worker thread and must never block.
+        if !self.ownership.is_owned() {
             return;
         }
 
-        // TODO: Use asynchronous variant if running in an async context.
-        // Note that if TempDir is used from the executor's handle,
-        //      this may block the executor itself.
-        // Using remove_dir_all to delete all content recursively.
+        // Synchronous on purpose: `Drop` must not re-enter the async runtime.
+        // Using remove_dir_all to delete all content recursively. `drop_async`
+        // provides an async deletion path at an explicit await point.
         let _ = std::fs::remove_dir_all(&self.path);
     }
 }

--- a/src/tempfile.rs
+++ b/src/tempfile.rs
@@ -11,7 +11,7 @@ use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 
 #[cfg(not(feature = "uuid"))]
 use crate::random_name::RandomName;
-use crate::{AtomicOwnership, Error, Ownership};
+use crate::{AtomicOwnership, Error, Ownership, PersistError};
 #[cfg(feature = "uuid")]
 use uuid::Uuid;
 
@@ -230,7 +230,7 @@ impl TempFile {
         dir: P,
     ) -> Result<Self, Error> {
         let dir = dir.borrow();
-        if !dir.is_dir() {
+        if !crate::path_is_dir(dir).await {
             return Err(Error::InvalidDirectory);
         }
         let path = dir.join(name.as_ref());
@@ -286,7 +286,7 @@ impl TempFile {
         path: P,
         ownership: Ownership,
     ) -> Result<Self, Error> {
-        if !path.borrow().is_file() {
+        if !crate::path_is_file(path.borrow()).await {
             return Err(Error::InvalidFile);
         }
         Self::new_internal(path, ownership, CreateMode::OpenExisting).await
@@ -403,11 +403,14 @@ impl TempFile {
     /// path. The file will no longer be deleted automatically.
     ///
     /// The move is performed with [`tokio::fs::rename`] and therefore must stay
-    /// on the same filesystem (a cross-device move returns an I/O error).
+    /// on the same filesystem (a cross-device move returns an error).
     ///
-    /// This is cancellation- and panic-safe: deletion is only disabled *after*
-    /// the rename succeeds, so if the future is dropped or the rename fails, the
-    /// original temporary file is still cleaned up.
+    /// On failure the temporary file is **not** deleted: it is left at its
+    /// original location and that path is returned in [`PersistError::path`], so
+    /// no data is lost on a cross-device or permission error. The caller may
+    /// re-wrap it with [`TempFile::from_existing`] to restore automatic cleanup,
+    /// or delete it. The local handle is closed before the rename so the move
+    /// also succeeds on Windows.
     ///
     /// ## Arguments
     ///
@@ -422,21 +425,34 @@ impl TempFile {
     /// let file = TempFile::new().await?;
     /// let target = std::env::temp_dir().join("persisted_async_tempfile.txt");
     ///
-    /// let path = file.persist(&target).await?;
+    /// let path = file.persist(&target).await.map_err(|e| e.error)?;
     /// assert!(fs::metadata(path.clone()).await.is_ok());
     /// # fs::remove_file(path).await.ok();
     /// # Ok::<(), Error>(())
     /// # });
     /// ```
-    pub async fn persist<P: AsRef<Path>>(self, target: P) -> Result<PathBuf, Error> {
+    pub async fn persist<P: AsRef<Path>>(self, target: P) -> Result<PathBuf, PersistError> {
         let target = target.as_ref().to_path_buf();
-        // Backstop ordering: rename first, disarm only on success. If the rename
-        // fails or this future is cancelled, `self` is dropped and its `Drop`
-        // deletes the original temporary file. The persisted target is never
-        // touched by `Drop`, which only ever removes the core's own `path`.
-        tokio::fs::rename(&self.core.path, &target).await?;
-        self.core.ownership.set_borrowed();
-        Ok(target)
+        let TempFile { file, core } = self;
+        // Close our handle before the rename: Windows refuses to move a file
+        // while a handle to it is open.
+        drop(file);
+
+        match tokio::fs::rename(&core.path, &target).await {
+            Ok(()) => {
+                core.ownership.set_borrowed();
+                Ok(target)
+            }
+            Err(e) => {
+                // Preserve the caller's data: leave the temporary in place and
+                // report where it is, rather than deleting it on the way out.
+                core.ownership.set_borrowed();
+                Err(PersistError {
+                    error: Error::Io(e),
+                    path: core.path.clone(),
+                })
+            }
+        }
     }
 
     /// Asynchronously drops the TempFile, ensuring any resources are properly released.
@@ -498,7 +514,7 @@ impl TempFile {
         prefix: &str,
         suffix: &str,
     ) -> Result<Self, Error> {
-        if !dir.is_dir() {
+        if !crate::path_is_dir(dir).await {
             return Err(Error::InvalidDirectory);
         }
         let mut last_err = None;

--- a/src/tempfile.rs
+++ b/src/tempfile.rs
@@ -1,39 +1,6 @@
-//! # async-tempfile
-//!
-//! Provides the [`TempFile`] struct, an asynchronous wrapper based on `tokio::fs` for temporary
-//! files that will be automatically deleted when the last reference to the struct is dropped.
-//!
-//! ```
-//! use async_tempfile::TempFile;
-//!
-//! #[tokio::main]
-//! async fn main() {
-//!     let parent = TempFile::new().await.unwrap();
-//!
-//!     // The cloned reference will not delete the file when dropped.
-//!     {
-//!         let nested = parent.open_rw().await.unwrap();
-//!         assert_eq!(nested.file_path(), parent.file_path());
-//!         assert!(nested.file_path().is_file());
-//!     }
-//!
-//!     // The file still exists; it will be deleted when `parent` is dropped.
-//!     assert!(parent.file_path().is_file());
-//! }
-//! ```
-//!
-//! ## Features
-//!
-//! * `uuid` - (Default) Enables random file name generation based on the [`uuid`](https://crates.io/crates/uuid) crate.
-//!            Provides the `new` and `new_in`, as well as the `new_with_uuid*` group of methods.
-
-// Document crate features on docs.rs.
-#![cfg_attr(docsrs, feature(doc_cfg))]
-// Required for dropping the file.
 use std::borrow::{Borrow, BorrowMut};
 use std::fmt::{Debug, Formatter};
-use std::io::{IoSlice, SeekFrom};
-use std::mem::ManuallyDrop;
+use std::io::{ErrorKind, IoSlice, SeekFrom};
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
@@ -44,23 +11,45 @@ use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 
 #[cfg(not(feature = "uuid"))]
 use crate::random_name::RandomName;
-use crate::Error;
-use crate::Ownership;
+use crate::{AtomicOwnership, Error, Ownership};
 #[cfg(feature = "uuid")]
 use uuid::Uuid;
 
-const FILE_PREFIX: &str = "atmp_";
+pub(crate) const FILE_PREFIX: &str = "atmp_";
+
+/// Maximum number of attempts to find a free name when creating a file with a
+/// randomly generated, collision-resistant name.
+const MAX_NAME_ATTEMPTS: usize = 16;
+
+/// How the underlying file should be opened or created.
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum CreateMode {
+    /// Create a brand-new file, failing if it already exists (`O_EXCL`).
+    /// Used for unpredictable, auto-generated names to avoid clobbering an
+    /// existing file or following a planted symlink.
+    Exclusive,
+    /// Create the file, or open it if it already exists. Used for user-supplied
+    /// names, preserving historic behavior.
+    CreateOrOpen,
+    /// Open an existing file without creating it. Used by `from_existing`.
+    OpenExisting,
+}
 
 /// A named temporary file that will be cleaned automatically
 /// after the last reference to it is dropped.
 pub struct TempFile {
     /// A local reference to the file. Used to write to or read from the file.
-    file: ManuallyDrop<File>,
+    ///
+    /// Field order matters: `file` is declared before `core` so that this local
+    /// handle is dropped (closed) before the shared `core` is released and the
+    /// file is deleted. Required for correct deletion on Windows, which refuses
+    /// to delete a file while a handle to it is open.
+    file: File,
 
     /// A shared pointer to the owned (or non-owned) file.
     /// The `Arc` ensures that the enclosed file is kept alive
     /// until all references to it are dropped.
-    core: ManuallyDrop<Arc<TempFileCore>>,
+    core: Arc<TempFileCore>,
 }
 
 /// The instance that tracks the temporary file.
@@ -69,13 +58,10 @@ struct TempFileCore {
     /// The path of the contained file.
     path: PathBuf,
 
-    /// Pointer to the file to keep it alive.
-    file: ManuallyDrop<File>,
-
-    /// A hacky approach to allow for "non-owned" files.
-    /// If set to `Ownership::Owned`, the file specified in `path` will be deleted
-    /// when this instance is dropped. If set to `Ownership::Borrowed`, the file will be kept.
-    ownership: Ownership,
+    /// Whether the file specified in `path` is owned (and deleted on drop) or
+    /// merely borrowed. Stored atomically because it is read from `Drop`, which
+    /// must never block on a lock, and mutated by `keep`/`persist`/`drop_async`.
+    ownership: AtomicOwnership,
 }
 
 impl TempFile {
@@ -119,7 +105,7 @@ impl TempFile {
     /// # use async_tempfile::{TempFile, Error};
     /// # use tokio::fs;
     /// # let _ = tokio_test::block_on(async {
-    /// let file = TempFile::new_with_name("temporary.file").await?;
+    /// let file = TempFile::new_with_name("new_with_name_example.file").await?;
     ///
     /// // The file exists.
     /// let file_path = file.file_path().clone();
@@ -174,6 +160,9 @@ impl TempFile {
     /// Creates a new temporary file in the specified location.
     /// When the instance goes out of scope, the file will be deleted.
     ///
+    /// The file is created with a collision-resistant, unpredictable name using
+    /// an exclusive (`O_EXCL`) create, so it never clobbers an existing file.
+    ///
     /// ## Crate Features
     ///
     /// * `uuid` - When the `uuid` crate feature is enabled, a random UUIDv4 is used to
@@ -204,17 +193,7 @@ impl TempFile {
     /// # Ok::<(), Error>(())
     /// # });
     pub async fn new_in<P: Borrow<Path>>(dir: P) -> Result<Self, Error> {
-        #[cfg(feature = "uuid")]
-        {
-            let id = Uuid::new_v4();
-            Self::new_with_uuid_in(id, dir).await
-        }
-
-        #[cfg(not(feature = "uuid"))]
-        {
-            let name = RandomName::new(FILE_PREFIX);
-            Self::new_with_name_in(name, dir).await
-        }
+        Self::create_with_affixes(dir.borrow(), FILE_PREFIX, "").await
     }
 
     /// Creates a new temporary file in the specified location.
@@ -232,7 +211,7 @@ impl TempFile {
     /// # use tokio::fs;
     /// # let _ = tokio_test::block_on(async {
     /// let path = std::env::temp_dir();
-    /// let file = TempFile::new_with_name_in("temporary.file", path).await?;
+    /// let file = TempFile::new_with_name_in("new_with_name_in_example.file", path).await?;
     ///
     /// // The file exists.
     /// let file_path = file.file_path().clone();
@@ -254,10 +233,8 @@ impl TempFile {
         if !dir.is_dir() {
             return Err(Error::InvalidDirectory);
         }
-        let file_name = name.as_ref();
-        let mut path = PathBuf::from(dir);
-        path.push(file_name);
-        Self::new_internal(path, Ownership::Owned).await
+        let path = dir.join(name.as_ref());
+        Self::new_internal(path, Ownership::Owned, CreateMode::CreateOrOpen).await
     }
 
     /// Creates a new temporary file in the specified location.
@@ -293,7 +270,7 @@ impl TempFile {
     #[cfg_attr(docsrs, doc(cfg(feature = "uuid")))]
     #[cfg(feature = "uuid")]
     pub async fn new_with_uuid_in<P: Borrow<Path>>(uuid: Uuid, dir: P) -> Result<Self, Error> {
-        let file_name = format!("{}{}", FILE_PREFIX, uuid);
+        let file_name = format!("{FILE_PREFIX}{uuid}");
         Self::new_with_name_in(file_name, dir).await
     }
 
@@ -312,7 +289,31 @@ impl TempFile {
         if !path.borrow().is_file() {
             return Err(Error::InvalidFile);
         }
-        Self::new_internal(path, ownership).await
+        Self::new_internal(path, ownership, CreateMode::OpenExisting).await
+    }
+
+    /// Creates a builder for configuring a new temporary file
+    /// (prefix, suffix, directory) before creating it.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # use async_tempfile::{TempFile, Error};
+    /// # let _ = tokio_test::block_on(async {
+    /// let file = TempFile::builder()
+    ///     .prefix("log_")
+    ///     .suffix(".txt")
+    ///     .create()
+    ///     .await?;
+    ///
+    /// let name = file.file_path().file_name().unwrap().to_string_lossy().into_owned();
+    /// assert!(name.starts_with("log_"));
+    /// assert!(name.ends_with(".txt"));
+    /// # Ok::<(), Error>(())
+    /// # });
+    /// ```
+    pub fn builder() -> crate::TempFileBuilder {
+        crate::TempFileBuilder::new()
     }
 
     /// Returns the path of the underlying temporary file.
@@ -328,8 +329,8 @@ impl TempFile {
             .open(&self.core.path)
             .await?;
         Ok(TempFile {
+            file,
             core: self.core.clone(),
-            file: ManuallyDrop::new(file),
         })
     }
 
@@ -341,19 +342,18 @@ impl TempFile {
             .open(&self.core.path)
             .await?;
         Ok(TempFile {
+            file,
             core: self.core.clone(),
-            file: ManuallyDrop::new(file),
         })
     }
 
     /// Creates a new TempFile instance that shares the same underlying
     /// file handle as the existing TempFile instance.
     /// Reads, writes, and seeks will affect both TempFile instances simultaneously.
-    #[allow(dead_code)]
     pub async fn try_clone(&self) -> Result<TempFile, Error> {
         Ok(TempFile {
+            file: self.file.try_clone().await?,
             core: self.core.clone(),
-            file: ManuallyDrop::new(self.file.try_clone().await?),
         })
     }
 
@@ -369,12 +369,84 @@ impl TempFile {
     /// # });
     /// ```
     pub fn ownership(&self) -> Ownership {
-        self.core.ownership
+        self.core.ownership.get()
+    }
+
+    /// Disables automatic deletion and returns the path of the underlying file,
+    /// turning the temporary file into a permanent one.
+    ///
+    /// This affects every clone that shares the same underlying file: none of
+    /// them will delete it when dropped.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # use async_tempfile::{TempFile, Error};
+    /// # use tokio::fs;
+    /// # let _ = tokio_test::block_on(async {
+    /// let file = TempFile::new().await?;
+    /// let path = file.keep();
+    ///
+    /// // The file still exists after the handle is dropped.
+    /// assert!(fs::metadata(path.clone()).await.is_ok());
+    /// # fs::remove_file(path).await.ok();
+    /// # Ok::<(), Error>(())
+    /// # });
+    /// ```
+    pub fn keep(self) -> PathBuf {
+        let path = self.core.path.clone();
+        self.core.ownership.set_borrowed();
+        path
+    }
+
+    /// Persists the temporary file by moving it to `target`, returning the new
+    /// path. The file will no longer be deleted automatically.
+    ///
+    /// The move is performed with [`tokio::fs::rename`] and therefore must stay
+    /// on the same filesystem (a cross-device move returns an I/O error).
+    ///
+    /// This is cancellation- and panic-safe: deletion is only disabled *after*
+    /// the rename succeeds, so if the future is dropped or the rename fails, the
+    /// original temporary file is still cleaned up.
+    ///
+    /// ## Arguments
+    ///
+    /// * `target` - The destination path to move the file to.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # use async_tempfile::{TempFile, Error};
+    /// # use tokio::fs;
+    /// # let _ = tokio_test::block_on(async {
+    /// let file = TempFile::new().await?;
+    /// let target = std::env::temp_dir().join("persisted_async_tempfile.txt");
+    ///
+    /// let path = file.persist(&target).await?;
+    /// assert!(fs::metadata(path.clone()).await.is_ok());
+    /// # fs::remove_file(path).await.ok();
+    /// # Ok::<(), Error>(())
+    /// # });
+    /// ```
+    pub async fn persist<P: AsRef<Path>>(self, target: P) -> Result<PathBuf, Error> {
+        let target = target.as_ref().to_path_buf();
+        // Backstop ordering: rename first, disarm only on success. If the rename
+        // fails or this future is cancelled, `self` is dropped and its `Drop`
+        // deletes the original temporary file. The persisted target is never
+        // touched by `Drop`, which only ever removes the core's own `path`.
+        tokio::fs::rename(&self.core.path, &target).await?;
+        self.core.ownership.set_borrowed();
+        Ok(target)
     }
 
     /// Asynchronously drops the TempFile, ensuring any resources are properly released.
     /// This is useful for explicitly managing the lifecycle of the TempFile
     /// in an asynchronous context.
+    ///
+    /// When this is the last reference to an owned file, the file is removed via
+    /// [`tokio::fs::remove_file`] without blocking the runtime. The synchronous
+    /// `Drop` remains armed as a backstop, so a cancelled or panicking
+    /// `drop_async` still cleans up the file.
     ///
     /// ## Example
     ///
@@ -392,29 +464,104 @@ impl TempFile {
     /// # });
     /// ```
     pub async fn drop_async(self) {
-        tokio::task::spawn_blocking(move || drop(self)).await.ok();
+        let TempFile { file, core } = self;
+        // Close the local read-write handle before attempting deletion.
+        drop(file);
+
+        // Only the sole owner removes the file asynchronously; otherwise the
+        // remaining references' `Drop` impls handle cleanup.
+        let Some(core) = Arc::into_inner(core) else {
+            return;
+        };
+
+        if core.ownership.is_owned() {
+            // `core` is still marked owned here. If this future is cancelled or
+            // panics at the await point, `core` is dropped and its synchronous
+            // `Drop` deletes the file. We disarm only after a confirmed removal.
+            match tokio::fs::remove_file(&core.path).await {
+                Ok(()) => core.ownership.set_borrowed(),
+                Err(e) if e.kind() == ErrorKind::NotFound => core.ownership.set_borrowed(),
+                // Leave armed: the synchronous `Drop` below retries the removal.
+                Err(_) => {}
+            }
+        }
+
+        drop(core);
     }
 
-    async fn new_internal<P: Borrow<Path>>(path: P, ownership: Ownership) -> Result<Self, Error> {
+    /// Creates a file named `{prefix}{random}{suffix}` with an unpredictable,
+    /// collision-resistant random core, using an exclusive (`O_EXCL`) create and
+    /// retrying on the (astronomically unlikely) collision. Shared by `new_in`
+    /// and [`crate::TempFileBuilder`].
+    pub(crate) async fn create_with_affixes(
+        dir: &Path,
+        prefix: &str,
+        suffix: &str,
+    ) -> Result<Self, Error> {
+        if !dir.is_dir() {
+            return Err(Error::InvalidDirectory);
+        }
+        let mut last_err = None;
+        for _ in 0..MAX_NAME_ATTEMPTS {
+            let name = format!("{prefix}{}{suffix}", Self::random_core_name());
+            match Self::new_internal(dir.join(name), Ownership::Owned, CreateMode::Exclusive).await
+            {
+                Ok(file) => return Ok(file),
+                Err(Error::Io(e)) if e.kind() == ErrorKind::AlreadyExists => {
+                    last_err = Some(Error::Io(e));
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Err(last_err.unwrap_or(Error::InvalidFile))
+    }
+
+    /// Generates the unpredictable, collision-resistant random core of a name,
+    /// without any prefix or suffix.
+    fn random_core_name() -> String {
+        #[cfg(feature = "uuid")]
+        {
+            Uuid::new_v4().to_string()
+        }
+
+        #[cfg(not(feature = "uuid"))]
+        {
+            RandomName::new("").as_str().to_string()
+        }
+    }
+
+    async fn new_internal<P: Borrow<Path>>(
+        path: P,
+        ownership: Ownership,
+        mode: CreateMode,
+    ) -> Result<Self, Error> {
         let path = path.borrow();
 
+        // A single read-write handle both creates (per `mode`) and serves the
+        // file. Keeping just this one handle alive holds the inode open for the
+        // lifetime of the (shared) core, so no separate keep-alive handle is
+        // needed - that only wasted a file descriptor per file.
+        let mut options = OpenOptions::new();
+        options.read(true).write(true);
+        match mode {
+            CreateMode::Exclusive => {
+                options.create_new(true);
+            }
+            CreateMode::CreateOrOpen => {
+                options.create(true);
+            }
+            CreateMode::OpenExisting => {}
+        }
+
+        let file = options.open(path).await?;
         let core = TempFileCore {
-            file: ManuallyDrop::new(
-                OpenOptions::new()
-                    .create(ownership == Ownership::Owned)
-                    .read(false)
-                    .write(true)
-                    .open(path)
-                    .await?,
-            ),
-            ownership,
+            ownership: AtomicOwnership::new(ownership),
             path: PathBuf::from(path),
         };
 
-        let file = OpenOptions::new().read(true).write(true).open(path).await?;
         Ok(Self {
-            file: ManuallyDrop::new(file),
-            core: ManuallyDrop::new(Arc::new(core)),
+            file,
+            core: Arc::new(core),
         })
     }
 
@@ -425,32 +572,23 @@ impl TempFile {
     }
 }
 
-/// Ensures the file handles are closed before the core reference is freed.
-/// If the core reference would be freed while handles are still open, it is
-/// possible that the underlying file cannot be deleted.
-impl Drop for TempFile {
-    fn drop(&mut self) {
-        // Ensure all file handles are closed before we attempt to delete the file itself via core.
-        drop(unsafe { ManuallyDrop::take(&mut self.file) });
-        drop(unsafe { ManuallyDrop::take(&mut self.core) });
-    }
-}
-
 /// Ensures that the underlying file is deleted if this is an owned instance.
 /// If the underlying file is not owned, this operation does nothing.
 impl Drop for TempFileCore {
     fn drop(&mut self) {
-        // Ensure we don't drop borrowed files.
-        if self.ownership != Ownership::Owned {
+        // Ensure we don't drop borrowed files. Read via the lock-free atomic:
+        // `Drop` may run on a runtime worker thread and must never block.
+        if !self.ownership.is_owned() {
             return;
         }
 
-        // Closing the file handle first, as otherwise the file might not be deleted.
-        drop(unsafe { ManuallyDrop::take(&mut self.file) });
-
-        // TODO: Use asynchronous variant if running in an async context.
-        // Note that if TempFile is used from the executor's handle,
-        //      this may block the executor itself.
+        // The owning `TempFile`'s handle (declared before `core`) has already
+        // been closed by the time this runs, so the file can be deleted even on
+        // platforms that lock open files (Windows).
+        //
+        // Synchronous on purpose: `Drop` must not re-enter the async runtime, as
+        // it may run on a runtime worker thread. Use `drop_async` for an async
+        // deletion path at an explicit await point.
         let _ = std::fs::remove_file(&self.path);
     }
 }
@@ -508,21 +646,21 @@ impl AsyncWrite for TempFile {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, std::io::Error>> {
-        Pin::new(self.file.deref_mut()).poll_write(cx, buf)
+        Pin::new(&mut self.file).poll_write(cx, buf)
     }
 
     fn poll_flush(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), std::io::Error>> {
-        Pin::new(self.file.deref_mut()).poll_flush(cx)
+        Pin::new(&mut self.file).poll_flush(cx)
     }
 
     fn poll_shutdown(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), std::io::Error>> {
-        Pin::new(self.file.deref_mut()).poll_shutdown(cx)
+        Pin::new(&mut self.file).poll_shutdown(cx)
     }
 
     fn poll_write_vectored(
@@ -530,29 +668,29 @@ impl AsyncWrite for TempFile {
         cx: &mut Context<'_>,
         bufs: &[IoSlice<'_>],
     ) -> Poll<Result<usize, std::io::Error>> {
-        Pin::new(self.file.deref_mut()).poll_write_vectored(cx, bufs)
+        Pin::new(&mut self.file).poll_write_vectored(cx, bufs)
     }
 }
 
-/// Forwarding AsyncWrite to the embedded TempFile
+/// Forwarding AsyncRead to the embedded File
 impl AsyncRead for TempFile {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
-        Pin::new(self.file.deref_mut()).poll_read(cx, buf)
+        Pin::new(&mut self.file).poll_read(cx, buf)
     }
 }
 
 /// Forwarding AsyncSeek to the embedded File
 impl AsyncSeek for TempFile {
     fn start_seek(mut self: Pin<&mut Self>, position: SeekFrom) -> std::io::Result<()> {
-        Pin::new(self.file.deref_mut()).start_seek(position)
+        Pin::new(&mut self.file).start_seek(position)
     }
 
     fn poll_complete(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<u64>> {
-        Pin::new(self.file.deref_mut()).poll_complete(cx)
+        Pin::new(&mut self.file).poll_complete(cx)
     }
 }
 

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -1,0 +1,90 @@
+//! Integration tests showcasing the `TempFile` / `TempDir` builders.
+
+use async_tempfile::{TempDir, TempFile};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+
+/// The builder, used end-to-end: configure a name, then write and read back data.
+#[tokio::test]
+async fn build_write_and_read_back() {
+    let mut file = TempFile::builder()
+        .prefix("report_")
+        .suffix(".txt")
+        .create()
+        .await
+        .unwrap();
+
+    // The configured prefix and suffix surround the random core.
+    let name = file
+        .file_path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    assert!(name.starts_with("report_"), "name was {name}");
+    assert!(name.ends_with(".txt"), "name was {name}");
+
+    // The handle is a fully usable async file.
+    file.write_all(b"hello builder").await.unwrap();
+    file.flush().await.unwrap();
+    file.rewind().await.unwrap();
+
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).await.unwrap();
+    assert_eq!(contents, "hello builder");
+}
+
+/// With no prefix/suffix configured, the default `atmp_` prefix is used.
+#[tokio::test]
+async fn build_with_defaults_uses_default_prefix() {
+    let file = TempFile::builder().create().await.unwrap();
+    let name = file
+        .file_path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    assert!(name.starts_with("atmp_"), "name was {name}");
+}
+
+/// The builder honors an explicit target directory.
+#[tokio::test]
+async fn build_in_explicit_directory() {
+    let parent = TempDir::new().await.unwrap();
+
+    let file = TempFile::builder()
+        .prefix("scoped_")
+        .dir(parent.dir_path().clone())
+        .create()
+        .await
+        .unwrap();
+
+    assert_eq!(file.file_path().parent().unwrap(), parent.dir_path());
+    assert!(file.file_path().is_file());
+}
+
+/// Two builds never collide, even with identical prefix/suffix.
+#[tokio::test]
+async fn builds_have_unique_names() {
+    let a = TempFile::builder().prefix("dup_").create().await.unwrap();
+    let b = TempFile::builder().prefix("dup_").create().await.unwrap();
+    assert_ne!(a.file_path(), b.file_path());
+}
+
+/// The directory builder creates a usable temporary directory.
+#[tokio::test]
+async fn build_directory_and_place_a_file_in_it() {
+    let dir = TempDir::builder().prefix("ws_").create().await.unwrap();
+    let dir_path = dir.dir_path().clone();
+
+    let name = dir_path.file_name().unwrap().to_string_lossy().into_owned();
+    assert!(name.starts_with("ws_"), "name was {name}");
+
+    // A file created inside the built directory lives under it.
+    let file = TempFile::new_in(dir_path.as_path()).await.unwrap();
+    assert_eq!(file.file_path().parent().unwrap(), dir_path);
+
+    // Dropping the directory removes it (and its contents) recursively.
+    drop(file);
+    drop(dir);
+    assert!(!dir_path.exists());
+}

--- a/tests/drop_safety.rs
+++ b/tests/drop_safety.rs
@@ -123,23 +123,36 @@ async fn drop_async_cancelled_still_deletes() {
 }
 
 #[tokio::test]
-async fn persist_failure_cleans_up() {
+async fn persist_failure_preserves_file_and_reports_path() {
     let file = TempFile::new().await.unwrap();
-    let path = file.file_path().clone();
+    let original = file.file_path().clone();
 
-    // Target parent directory does not exist → rename fails.
-    let bad_target = path.join("nonexistent").join("subdir").join("target.bin");
-    let result = file.persist(&bad_target).await;
+    // A fresh, non-existent directory under temp_dir() → the rename fails
+    // reliably because the target's parent directory is missing.
+    let missing_dir =
+        std::env::temp_dir().join(format!("async_tempfile_missing_{}", std::process::id()));
+    let _ = tokio::fs::remove_dir_all(&missing_dir).await;
+    let bad_target = missing_dir.join("target.bin");
 
+    let err = file
+        .persist(&bad_target)
+        .await
+        .expect_err("persist into a missing directory must fail");
+
+    // The data is not lost: the temporary still exists at the reported path.
+    assert_eq!(err.path, original);
     assert!(
-        result.is_err(),
-        "persist into a missing directory must fail"
-    );
-    assert!(
-        !path.exists(),
-        "a failed persist must still delete the original temp file"
+        original.exists(),
+        "a failed persist must NOT delete the original temp file"
     );
     assert!(!bad_target.exists());
+
+    // The caller can recover it; re-adopting restores automatic cleanup.
+    let recovered = TempFile::from_existing(original.clone(), Ownership::Owned)
+        .await
+        .unwrap();
+    drop(recovered);
+    assert!(!original.exists());
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/drop_safety.rs
+++ b/tests/drop_safety.rs
@@ -1,0 +1,296 @@
+//! Tests for the drop-safety contract: temporary files/directories are always
+//! cleaned up (even under cancellation or panic) and dropping never deadlocks.
+//!
+//! See the project plan's "Drop-safety contract" for the invariants exercised
+//! here:
+//!   1. lock-free core → `Drop` cannot deadlock on a lock
+//!   2. synchronous `Drop` never re-enters the runtime
+//!   3. the synchronous `Drop` is the always-armed backstop; async paths disarm
+//!      only after success → cancellation/panic always falls back to cleanup
+//!   4. field order closes handles before deletion
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use async_tempfile::{Ownership, TempDir, TempFile};
+
+const WATCHDOG: Duration = Duration::from_secs(5);
+
+// ---------------------------------------------------------------------------
+// A. Feature/behavior
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn keep_prevents_deletion() {
+    let file = TempFile::new().await.unwrap();
+    assert_eq!(file.ownership(), Ownership::Owned);
+    let path = file.keep();
+
+    assert!(path.is_file(), "kept file must survive the dropped handle");
+    tokio::fs::remove_file(path).await.unwrap();
+}
+
+#[tokio::test]
+async fn keep_affects_clones_sharing_the_core() {
+    let file = TempFile::new().await.unwrap();
+    let clone = file.open_rw().await.unwrap();
+    let path = file.file_path().clone();
+
+    // Keeping via one handle disables deletion for the shared underlying file.
+    let _ = file.keep();
+    drop(clone);
+
+    assert!(path.is_file(), "clone must not delete a kept file");
+    tokio::fs::remove_file(path).await.unwrap();
+}
+
+#[tokio::test]
+async fn persist_moves_and_survives() {
+    let file = TempFile::new().await.unwrap();
+    let original = file.file_path().clone();
+    let target = std::env::temp_dir().join(format!("persist_test_{}.bin", std::process::id()));
+    let _ = tokio::fs::remove_file(&target).await;
+
+    let persisted = file.persist(&target).await.unwrap();
+    assert_eq!(persisted, target);
+    assert!(persisted.is_file(), "persisted file must exist");
+    assert!(
+        !original.exists(),
+        "original temp path must be gone after move"
+    );
+
+    tokio::fs::remove_file(target).await.unwrap();
+}
+
+#[tokio::test]
+async fn builder_honors_prefix_and_suffix() {
+    let file = TempFile::builder()
+        .prefix("pfx_")
+        .suffix(".sfx")
+        .create()
+        .await
+        .unwrap();
+
+    let name = file
+        .file_path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    assert!(name.starts_with("pfx_"), "name was {name}");
+    assert!(name.ends_with(".sfx"), "name was {name}");
+}
+
+#[tokio::test]
+async fn dir_builder_and_persist() {
+    let dir = TempDir::builder().prefix("dirpfx_").create().await.unwrap();
+    let name = dir
+        .dir_path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    assert!(name.starts_with("dirpfx_"), "name was {name}");
+
+    let target = std::env::temp_dir().join(format!("persist_dir_{}", std::process::id()));
+    let _ = tokio::fs::remove_dir_all(&target).await;
+    let persisted = dir.persist(&target).await.unwrap();
+    assert!(persisted.is_dir());
+    tokio::fs::remove_dir_all(persisted).await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// B. Cleanup under cancellation (invariant 3)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn drop_async_cancelled_still_deletes() {
+    let file = TempFile::new().await.unwrap();
+    let path = file.file_path().clone();
+    assert!(path.is_file());
+
+    // Drive `drop_async` until it parks at the `remove_file` await, then drop
+    // the future without completing it. The synchronous backstop in `Drop` must
+    // still delete the file.
+    let mut fut = tokio_test::task::spawn(file.drop_async());
+    let _ = fut.poll();
+    drop(fut);
+
+    assert!(
+        !path.exists(),
+        "a cancelled drop_async must still delete the file via the sync backstop"
+    );
+}
+
+#[tokio::test]
+async fn persist_failure_cleans_up() {
+    let file = TempFile::new().await.unwrap();
+    let path = file.file_path().clone();
+
+    // Target parent directory does not exist → rename fails.
+    let bad_target = path.join("nonexistent").join("subdir").join("target.bin");
+    let result = file.persist(&bad_target).await;
+
+    assert!(
+        result.is_err(),
+        "persist into a missing directory must fail"
+    );
+    assert!(
+        !path.exists(),
+        "a failed persist must still delete the original temp file"
+    );
+    assert!(!bad_target.exists());
+}
+
+// ---------------------------------------------------------------------------
+// C. Panic-safety (invariant 3)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn panic_while_holding_deletes_file() {
+    use std::sync::{Arc, Mutex};
+
+    let captured: Arc<Mutex<Option<std::path::PathBuf>>> = Arc::new(Mutex::new(None));
+    let captured_clone = captured.clone();
+
+    let handle = std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let file = TempFile::new().await.unwrap();
+            *captured_clone.lock().unwrap() = Some(file.file_path().clone());
+            panic!("boom while holding a TempFile");
+        });
+    });
+
+    // The spawned thread panics; unwinding must run the file's `Drop`.
+    assert!(handle.join().is_err(), "thread was expected to panic");
+
+    let path = captured.lock().unwrap().clone().expect("path was captured");
+    assert!(
+        !path.exists(),
+        "a TempFile must be deleted while unwinding from a panic"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// D. Deadlock watchdog (invariants 1 & 2)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sync_drop_on_multi_thread_runtime_does_not_deadlock() {
+    let path = tokio::time::timeout(WATCHDOG, async {
+        let file = TempFile::new().await.unwrap();
+        let path = file.file_path().clone();
+        drop(file); // synchronous Drop on a runtime worker thread
+        path
+    })
+    .await
+    .expect("synchronous drop must not deadlock on a multi-thread runtime");
+
+    assert!(!path.exists());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn sync_drop_on_current_thread_runtime_does_not_deadlock() {
+    let path = tokio::time::timeout(WATCHDOG, async {
+        let dir = TempDir::new().await.unwrap();
+        let path = dir.dir_path().clone();
+        drop(dir);
+        path
+    })
+    .await
+    .expect("synchronous drop must not deadlock on a current-thread runtime");
+
+    assert!(!path.exists());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn drop_async_does_not_deadlock() {
+    let path = tokio::time::timeout(WATCHDOG, async {
+        let file = TempFile::new().await.unwrap();
+        let path = file.file_path().clone();
+        file.drop_async().await;
+        path
+    })
+    .await
+    .expect("drop_async must not deadlock");
+
+    assert!(!path.exists());
+}
+
+// ---------------------------------------------------------------------------
+// E. Stress / leak detection (no leaks, no double-free, names unique)
+// ---------------------------------------------------------------------------
+
+// Modest concurrency: these run in parallel with every other test in this
+// binary, so the peak open-file-descriptor count must stay well under a typical
+// `ulimit -n` of 1024. Each live `TempFile` holds exactly one descriptor.
+const TASKS: u32 = 8;
+const ITERS: u32 = 25;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stress_concurrent_create_and_drop_leaves_nothing() {
+    let dir = TempDir::new().await.unwrap();
+    let dir_path = dir.dir_path().clone();
+
+    let mut handles = Vec::new();
+    for task in 0..TASKS {
+        let d = dir_path.clone();
+        handles.push(tokio::spawn(async move {
+            for _ in 0..ITERS {
+                let file = TempFile::new_in(d.as_path()).await.unwrap();
+                // Exercise the shared-core clone path too.
+                let clone = file.open_rw().await.unwrap();
+                drop(clone);
+                // Alternate between the sync and async drop paths.
+                if task % 2 == 0 {
+                    file.drop_async().await;
+                } else {
+                    drop(file);
+                }
+            }
+        }));
+    }
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    // Every created file is owned and dropped → the directory must be empty.
+    let mut entries = tokio::fs::read_dir(&dir_path).await.unwrap();
+    let mut leftover = Vec::new();
+    while let Some(entry) = entries.next_entry().await.unwrap() {
+        leftover.push(entry.file_name());
+    }
+    assert!(leftover.is_empty(), "temporary files leaked: {leftover:?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_auto_names_are_unique() {
+    let dir = TempDir::new().await.unwrap();
+    let dir_path = dir.dir_path().clone();
+
+    let mut handles = Vec::new();
+    for _ in 0..TASKS {
+        let d = dir_path.clone();
+        handles.push(tokio::spawn(async move {
+            let mut paths = Vec::new();
+            for _ in 0..ITERS {
+                // The per-process counter (and UUIDv4 under the `uuid` feature)
+                // makes every generated name unique for the lifetime of the
+                // process, so the file can be dropped immediately - no need to
+                // hold descriptors open to prove uniqueness.
+                let file = TempFile::new_in(d.as_path()).await.unwrap();
+                paths.push(file.file_path().clone());
+            }
+            paths
+        }));
+    }
+
+    let mut all = HashSet::new();
+    for handle in handles {
+        for path in handle.await.unwrap() {
+            assert!(all.insert(path.clone()), "duplicate temp name: {path:?}");
+        }
+    }
+    assert_eq!(all.len() as u32, TASKS * ITERS);
+}


### PR DESCRIPTION
Modernizes `async-tempfile` for the 0.8.0 release. The crate now compiles with `#![forbid(unsafe_code)]`, generates unpredictable temporary names, and gains a builder plus `keep`/`persist` for turning a temporary into a permanent file or directory. Existing APIs are unchanged.

## Why

The drop machinery relied on `ManuallyDrop` + `unsafe`, automatically generated names were predictable and created without `O_EXCL` (a preexisting-file / symlink race), and there was no way to keep or relocate a temporary. This release closes those gaps while keeping the public surface backward compatible.

## Key changes

- **Forbid unsafe.** The local file handle is declared before the shared core, so field drop order closes it before the core deletes the file (still correct on Windows). The `ManuallyDrop`/`unsafe` machinery is gone.
- **Lock-free ownership.** Ownership lives in an atomic so `Drop` can read it without ever blocking, and `keep`/`persist`/`drop_async` can flip it at runtime.
- **`keep` and `persist`.** Disable auto-deletion, or move the file/directory to a permanent path. Both are cancellation- and panic-safe: the synchronous `Drop` stays armed as a backstop and is disarmed only after the operation succeeds.
- **Builder.** `TempFile::builder()` / `TempDir::builder()` configure prefix, suffix and target directory.
- **Hardened names.** Auto-generated names are seeded from the OS RNG (plus a per-process counter for guaranteed local uniqueness) and created with an exclusive (`O_EXCL`) create. User-supplied names keep create-or-open behavior.
- **Async drop.** `drop_async` deletes via `tokio::fs` directly when it is the sole owner, instead of offloading a blocking synchronous drop.
- **Fewer descriptors.** Each `TempFile` previously held a redundant keep-alive handle; removing it halves open descriptors per file.
- Edition 2024, MSRV 1.85, and a `Taskfile.dist.yaml` mirroring CI.

## Notes for reviewers

The drop-safety contract is the heart of the change, so start in `src/tempfile.rs`: the `TempFile`/`TempFileCore` struct definitions (note the field-order comment), then `Drop for TempFileCore`, `persist`, and `drop_async` — these implement the "synchronous Drop is the always-armed backstop; async paths disarm only after success" rule. `src/tempdir.rs` mirrors it. `tests/drop_safety.rs` encodes that contract: cleanup under cancellation and panic, a deadlock watchdog on both runtime flavors, and a leak/uniqueness stress test (it passes under `ulimit -n 64`). `src/builder.rs` and `tests/builder.rs` are self-contained.

Behavior change to be aware of: the auto-name path now uses `O_EXCL`, so it will not silently reuse an existing file the way the old `.create()` path could; user-supplied names are unaffected.

Closes #11. Closes #12. Refs #1 (improves `drop_async`; true async drop remains blocked on stable Rust). Supersedes the draft in #8, whose double-free concern is removed by dropping `ManuallyDrop`.