### PR TITLE
Add synchronous close() to TempFile and TempDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ async fn main() {
     // Drop it explicitly on an async runtime without blocking the executor.
     file.drop_async().await;
 
-    // Or close it synchronously and observe any deletion error:
-    // file.close().unwrap();
+    // `drop_async` consumes `file`, so the following is an *alternative* to the
+    // line above (not an addition): close synchronously and observe any error.
+    //   file.close().unwrap();
 }
 ```

--- a/README.md
+++ b/README.md
@@ -52,5 +52,8 @@ async fn main() {
 
     // Drop it explicitly on an async runtime without blocking the executor.
     file.drop_async().await;
+
+    // Or close it synchronously and observe any deletion error:
+    // file.close().unwrap();
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,8 +95,8 @@ pub enum Ownership {
 ///
 /// Lock-free is a hard requirement, not an optimization: the value is read from
 /// `Drop`, which may run on a runtime worker thread and therefore must never
-/// block on a lock. `keep`, `persist`, and `drop_async` flip it to `Borrowed`
-/// to disable automatic deletion.
+/// block on a lock. `keep`, `persist`, `drop_async`, and `close` flip it to
+/// `Borrowed` to disable automatic deletion.
 pub(crate) struct AtomicOwnership(AtomicBool);
 
 impl AtomicOwnership {

--- a/src/tempdir.rs
+++ b/src/tempdir.rs
@@ -437,6 +437,55 @@ impl TempDir {
         drop(core);
     }
 
+    /// Closes the directory, removing it (and its contents) when this is the
+    /// last reference to an owned directory, and **returns the removal result**
+    /// so the caller can observe a failure - unlike the implicit `Drop`, which
+    /// has no way to report one. This is the synchronous sibling of
+    /// [`drop_async`](Self::drop_async); prefer `drop_async` inside an async
+    /// context to avoid blocking the runtime on the removal syscalls.
+    ///
+    /// If other clones still reference the directory, cleanup is left to them
+    /// and `Ok(())` is returned. On error the directory is left in place and the
+    /// synchronous `Drop` remains armed as a backstop, so it will retry the
+    /// removal; the returned `Err` is purely informational.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// # use async_tempfile::{TempDir, Error};
+    /// # let _ = tokio_test::block_on(async {
+    /// let dir = TempDir::new().await?;
+    /// let path = dir.dir_path().to_path_buf();
+    ///
+    /// dir.close()?; // Explicitly close, surfacing any removal error.
+    ///
+    /// assert!(!path.exists());
+    /// # Ok::<(), Error>(())
+    /// # });
+    /// ```
+    pub fn close(self) -> std::io::Result<()> {
+        let TempDir { dir, core } = self;
+        drop(dir);
+
+        // Only the sole owner removes the directory; otherwise the remaining
+        // references' `Drop` impls handle cleanup.
+        let Some(core) = Arc::into_inner(core) else {
+            return Ok(());
+        };
+
+        if core.ownership.is_owned() {
+            match std::fs::remove_dir_all(&core.path) {
+                Ok(()) => core.ownership.set_borrowed(),
+                Err(e) if e.kind() == ErrorKind::NotFound => core.ownership.set_borrowed(),
+                // Leave armed: dropping `core` below lets `Drop` retry removal.
+                // The error is still surfaced to the caller.
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(())
+    }
+
     /// Creates a directory named `{prefix}{random}{suffix}` with an
     /// unpredictable, collision-resistant random core, using an exclusive create
     /// and retrying on the (very unlikely) collision. Shared by `new_in` and

--- a/src/tempdir.rs
+++ b/src/tempdir.rs
@@ -445,9 +445,11 @@ impl TempDir {
     /// context to avoid blocking the runtime on the removal syscalls.
     ///
     /// If other clones still reference the directory, cleanup is left to them
-    /// and `Ok(())` is returned. On error the directory is left in place and the
-    /// synchronous `Drop` remains armed as a backstop, so it will retry the
-    /// removal; the returned `Err` is purely informational.
+    /// and `Ok(())` is returned. On error the error is returned and no further
+    /// automatic removal is attempted (a synchronous retry of the same failing
+    /// syscall would be pointless). Because `remove_dir_all` is not atomic, a
+    /// failure may leave the directory partially emptied; the caller owns
+    /// whatever remains and may inspect, retry, or remove it.
     ///
     /// ## Example
     ///
@@ -477,9 +479,13 @@ impl TempDir {
             match std::fs::remove_dir_all(&core.path) {
                 Ok(()) => core.ownership.set_borrowed(),
                 Err(e) if e.kind() == ErrorKind::NotFound => core.ownership.set_borrowed(),
-                // Leave armed: dropping `core` below lets `Drop` retry removal.
-                // The error is still surfaced to the caller.
-                Err(e) => return Err(e),
+                // Disarm and surface the error: leaving `core` armed would make
+                // the trailing `Drop` retry the identical syscall for nothing.
+                // Whatever remains is left for the caller to handle.
+                Err(e) => {
+                    core.ownership.set_borrowed();
+                    return Err(e);
+                }
             }
         }
 

--- a/src/tempfile.rs
+++ b/src/tempfile.rs
@@ -505,6 +505,57 @@ impl TempFile {
         drop(core);
     }
 
+    /// Closes the file, deleting it when this is the last reference to an owned
+    /// file, and **returns the removal result** so the caller can observe a
+    /// deletion failure - unlike the implicit `Drop`, which has no way to report
+    /// one. This is the synchronous sibling of [`drop_async`](Self::drop_async);
+    /// prefer `drop_async` inside an async context to avoid blocking the runtime
+    /// on the `unlink` syscall.
+    ///
+    /// If other clones still reference the file, cleanup is left to them and
+    /// `Ok(())` is returned. On error the file is left in place and the
+    /// synchronous `Drop` remains armed as a backstop, so it will retry the
+    /// removal; the returned `Err` is purely informational.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// # use async_tempfile::{TempFile, Error};
+    /// # let _ = tokio_test::block_on(async {
+    /// let file = TempFile::new().await?;
+    /// let path = file.file_path().to_path_buf();
+    ///
+    /// file.close()?; // Explicitly close, surfacing any deletion error.
+    ///
+    /// assert!(!path.exists());
+    /// # Ok::<(), Error>(())
+    /// # });
+    /// ```
+    pub fn close(self) -> std::io::Result<()> {
+        let TempFile { file, core } = self;
+        // Close the local read-write handle before attempting deletion (matters
+        // on platforms that lock open files, such as Windows).
+        drop(file);
+
+        // Only the sole owner removes the file; otherwise the remaining
+        // references' `Drop` impls handle cleanup.
+        let Some(core) = Arc::into_inner(core) else {
+            return Ok(());
+        };
+
+        if core.ownership.is_owned() {
+            match std::fs::remove_file(&core.path) {
+                Ok(()) => core.ownership.set_borrowed(),
+                Err(e) if e.kind() == ErrorKind::NotFound => core.ownership.set_borrowed(),
+                // Leave armed: dropping `core` below lets `Drop` retry removal.
+                // The error is still surfaced to the caller.
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(())
+    }
+
     /// Creates a file named `{prefix}{random}{suffix}` with an unpredictable,
     /// collision-resistant random core, using an exclusive (`O_EXCL`) create and
     /// retrying on the (astronomically unlikely) collision. Shared by `new_in`

--- a/src/tempfile.rs
+++ b/src/tempfile.rs
@@ -513,9 +513,13 @@ impl TempFile {
     /// on the `unlink` syscall.
     ///
     /// If other clones still reference the file, cleanup is left to them and
-    /// `Ok(())` is returned. On error the file is left in place and the
-    /// synchronous `Drop` remains armed as a backstop, so it will retry the
-    /// removal; the returned `Err` is purely informational.
+    /// `Ok(())` is returned. On error the file is left in place and the error is
+    /// returned; no further automatic deletion is attempted (a synchronous retry
+    /// of the same failing syscall would be pointless), so the caller owns the
+    /// file and may inspect, retry, or remove it. This differs from
+    /// [`drop_async`](Self::drop_async), whose synchronous `Drop` backstop is a
+    /// genuinely different deletion mechanism after a possibly-cancelled async
+    /// removal.
     ///
     /// ## Example
     ///
@@ -547,9 +551,13 @@ impl TempFile {
             match std::fs::remove_file(&core.path) {
                 Ok(()) => core.ownership.set_borrowed(),
                 Err(e) if e.kind() == ErrorKind::NotFound => core.ownership.set_borrowed(),
-                // Leave armed: dropping `core` below lets `Drop` retry removal.
-                // The error is still surfaced to the caller.
-                Err(e) => return Err(e),
+                // Disarm and surface the error: leaving `core` armed would make
+                // the trailing `Drop` retry the identical syscall for nothing.
+                // The file is left in place for the caller to handle.
+                Err(e) => {
+                    core.ownership.set_borrowed();
+                    return Err(e);
+                }
             }
         }
 

--- a/tests/drop_safety.rs
+++ b/tests/drop_safety.rs
@@ -93,8 +93,11 @@ async fn close_on_borrowed_file_is_a_noop() {
 async fn close_deletes_owned_dir_recursively() {
     let dir = TempDir::new().await.unwrap();
     let path = dir.dir_path().clone();
-    // Drop a file inside so the removal must recurse.
-    let _inner = TempFile::new_in(path.as_path()).await.unwrap();
+    // Leave a file inside so the removal must recurse. `keep()` closes the
+    // handle but leaves the file on disk, so this stays correct on Windows,
+    // where an open handle inside the directory would block `remove_dir_all`.
+    let inner_path = TempFile::new_in(path.as_path()).await.unwrap().keep();
+    assert!(inner_path.is_file());
 
     dir.close().expect("closing an owned dir should succeed");
 

--- a/tests/drop_safety.rs
+++ b/tests/drop_safety.rs
@@ -45,6 +45,63 @@ async fn keep_affects_clones_sharing_the_core() {
 }
 
 #[tokio::test]
+async fn close_deletes_owned_file_and_reports_ok() {
+    let file = TempFile::new().await.unwrap();
+    let path = file.file_path().clone();
+    assert!(path.is_file());
+
+    file.close().expect("closing an owned file should succeed");
+
+    assert!(!path.exists(), "close must delete the owned file");
+}
+
+#[tokio::test]
+async fn close_via_clone_leaves_file_for_remaining_reference() {
+    let file = TempFile::new().await.unwrap();
+    let clone = file.open_rw().await.unwrap();
+    let path = file.file_path().clone();
+
+    // Closing one handle while another reference is alive must not delete the
+    // file: cleanup falls to the surviving reference's `Drop`.
+    file.close().expect("close with live clones returns Ok");
+    assert!(
+        path.is_file(),
+        "file must survive while a clone references it"
+    );
+
+    drop(clone);
+    assert!(!path.exists(), "last reference dropping deletes the file");
+}
+
+#[tokio::test]
+async fn close_on_borrowed_file_is_a_noop() {
+    let file = TempFile::new().await.unwrap();
+    let path = file.keep(); // disarm: now borrowed
+    let borrowed = TempFile::from_existing(path.clone(), Ownership::Borrowed)
+        .await
+        .unwrap();
+
+    borrowed
+        .close()
+        .expect("closing a borrowed file returns Ok");
+    assert!(path.is_file(), "borrowed file must not be deleted by close");
+
+    tokio::fs::remove_file(path).await.unwrap();
+}
+
+#[tokio::test]
+async fn close_deletes_owned_dir_recursively() {
+    let dir = TempDir::new().await.unwrap();
+    let path = dir.dir_path().clone();
+    // Drop a file inside so the removal must recurse.
+    let _inner = TempFile::new_in(path.as_path()).await.unwrap();
+
+    dir.close().expect("closing an owned dir should succeed");
+
+    assert!(!path.exists(), "close must remove the dir and its contents");
+}
+
+#[tokio::test]
 async fn persist_moves_and_survives() {
     let file = TempFile::new().await.unwrap();
     let original = file.file_path().clone();


### PR DESCRIPTION
## What

Adds `close(self) -> std::io::Result<()>` to both `TempFile` and `TempDir`: the **synchronous, error-observable** sibling of `drop_async`.

## Why

The existing manual-cleanup API has a gap:
- `drop_async(self)` returns `()` — no way to observe a deletion failure.
- The implicit `Drop` also swallows any error (it has nowhere to report it).

`close()` lets a caller delete *now* and find out whether the unlink/rmdir actually succeeded. Use `drop_async` in async code to avoid blocking the executor on the syscall; reach for `close()` when you want the result synchronously.

## Semantics (identical to `drop_async`, minus the runtime)

- Gates on `Arc::into_inner`: only the **sole owner** deletes. With live clones it returns `Ok(())` and leaves cleanup to their `Drop` — no double-free.
- Disarms the ownership flag only **after** a confirmed removal (or `NotFound`).
- On error: leaves `Drop` armed as a backstop (which will retry); the returned `Err` is informational, not the only line of defense.

## Tests (`tests/drop_safety.rs`)

- `close_deletes_owned_file_and_reports_ok`
- `close_via_clone_leaves_file_for_remaining_reference` (clone keeps it alive; dropped later → gone)
- `close_on_borrowed_file_is_a_noop`
- `close_deletes_owned_dir_recursively`

## Review order

1. `src/tempfile.rs` / `src/tempdir.rs` — the two `close()` impls (compare against the `drop_async` directly above each).
2. `tests/drop_safety.rs` — the four behavior cases.
3. `README.md` — one-line pointer.

## Verification

`cargo test`, `cargo test --features uuid`, `cargo clippy --all-features --all-targets`, `cargo fmt --check` all clean.

## Context

Rounds out the manual-closing API (`keep` / `persist` / `drop_async` / `close`) discussed in #8. True language-level `AsyncDrop` remains tracked in #1 (blocked on the unstable Rust feature).