### PR TITLE
Backfill 0.8.0 changelog (close, InvalidAffix, coverage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `drop_async` now removes the file or directory via `tokio::fs` directly when it
   is the sole owner, rather than offloading a synchronous drop to a blocking
   thread. The synchronous `Drop` remains an always-armed backstop.
+- [#15](https://github.com/sunsided/async-tempfile-rs/pull/15):
+  Added `close` to `TempFile` and `TempDir`: a synchronous, error-observable
+  deletion returning `io::Result<()>`, complementing `drop_async`. On a deletion
+  error it disarms automatic cleanup and leaves the file or directory in place
+  for the caller to handle.
 
 ### Changed
 
@@ -35,7 +40,16 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   uniqueness) and created with an exclusive (`O_EXCL`) create, closing a
   predictable-name / preexisting-file race. User-supplied names keep their
   previous create-or-open behavior.
+- [#14](https://github.com/sunsided/async-tempfile-rs/pull/14):
+  A name `prefix` or `suffix` containing a path separator is now rejected with
+  the new `Error::InvalidAffix`, so a composed name can no longer escape the
+  target directory via `../` traversal or an absolute-path replacement.
 - Bumped the crate to Rust edition 2024 with a declared MSRV of 1.85.
+
+### Internal
+
+- [#16](https://github.com/sunsided/async-tempfile-rs/pull/16):
+  Raised test coverage from ~67% to ~94%.
 
 ## [0.7.0] - 2025-02-22
 


### PR DESCRIPTION
## What

Adds the three 0.8.0 changes that were missing from `CHANGELOG.md` but shipped in the tagged + published `v0.8.0` (and are now on the [GitHub release](https://github.com/sunsided/async-tempfile-rs/releases/tag/v0.8.0)):

- **Added** — `close()` on `TempFile`/`TempDir`, the synchronous error-observable sibling of `drop_async` (#15)
- **Changed** — path-separator `prefix`/`suffix` rejected with the new `Error::InvalidAffix`, preventing directory escape (#14)
- **Internal** — test coverage ~67% → ~94% (#16)

## Why

The `CHANGELOG.md` 0.8.0 section only covered the #13 work (builder/keep/persist/drop_async/forbid-unsafe/unpredictable names). #14 and #15 landed afterward and were tagged into 0.8.0 without changelog entries, so the in-repo changelog understated what 0.8.0 actually contains. This brings it in line with the release notes and crates.io.

## Note

Docs-only; no code change. The version line stays `0.8.0` — these edits describe the already-released version, they don't introduce a new one.